### PR TITLE
[asdl/runtime] Add deriving clause / Use ASDL for the ControlFlow exception type

### DIFF
--- a/asdl/ast.py
+++ b/asdl/ast.py
@@ -188,9 +188,10 @@ class Constructor(_CompoundAST):
 
 
 class Sum(AST):
-    def __init__(self, types, generate=None):
+    def __init__(self, types, generate=None, deriving=None):
         self.types = types  # type: List[Constructor]
         self.generate = generate or []
+        self.deriving = deriving or []
 
     def Print(self, f, indent):
         ind = indent * '  '
@@ -199,6 +200,8 @@ class Sum(AST):
             t.Print(f, indent + 1)
         if self.generate:
             f.write('%s  generate %s\n' % (ind, self.generate))
+        if self.deriving:
+            f.write('%s  deriving %s\n' % (ind, self.deriving))
         f.write('%s}\n' % ind)
 
 

--- a/asdl/front_end.py
+++ b/asdl/front_end.py
@@ -10,7 +10,7 @@ from asdl.util import log
 
 _ = log
 
-_KEYWORDS = ['use', 'module', 'generate']
+_KEYWORDS = ['use', 'module', 'generate', 'deriving']
 
 _TOKENS = [
     ('Keyword', ''),
@@ -249,6 +249,7 @@ class ASDLParser(object):
                     break
                 self._advance()
             generate = self._parse_optional_generate()
+            deriving = self._parse_optional_deriving()
 
             # Additional validation
             if generate is not None:
@@ -258,9 +259,9 @@ class ASDLParser(object):
                                               self.cur_token.lineno)
 
             if _SumIsSimple(sumlist):
-                return SimpleSum(sumlist, generate)
+                return SimpleSum(sumlist, generate, deriving)
             else:
-                return Sum(sumlist, generate)
+                return Sum(sumlist, generate, deriving)
 
     def _parse_type_expr(self):
         """One or two params:
@@ -348,12 +349,12 @@ class ASDLParser(object):
 
         list      : '[' list_inner? ']'
         """
-        generate = []
+        items = []
         self._match(TokenKind.LBracket)
         while self.cur_token.kind == TokenKind.Name:
             name = self._match(TokenKind.Name)
 
-            generate.append(name)
+            items.append(name)
 
             if self.cur_token.kind == TokenKind.RBracket:
                 break
@@ -361,11 +362,19 @@ class ASDLParser(object):
                 self._advance()
 
         self._match(TokenKind.RBracket)
-        return generate
+        return items
 
     def _parse_optional_generate(self):
         """Attributes = 'generate' list."""
         if self._at_keyword('generate'):
+            self._advance()
+            return self._parse_list()
+        else:
+            return None
+
+    def _parse_optional_deriving(self):
+        """Attributes = 'deriving' list."""
+        if self._at_keyword('deriving'):
             self._advance()
             return self._parse_list()
         else:

--- a/asdl/gen_cpp.py
+++ b/asdl/gen_cpp.py
@@ -340,7 +340,8 @@ class ClassDefVisitor(visitor.AsdlVisitor):
         self.debug_info['%s_t' % sum_name] = int_to_type
 
         # This is the base class.
-        Emit('class %(sum_name)s_t {')
+        deriving = " : " + ", ".join(sum.deriving) if sum.deriving else "";
+        Emit('class %(sum_name)s_t%(deriving)s {')
         # Can't be constructed directly.  Note: this shows up in uftrace in debug
         # mode, e.g. when we intantiate Token.  Do we need it?
         Emit(' protected:')

--- a/asdl/gen_python.py
+++ b/asdl/gen_python.py
@@ -470,7 +470,9 @@ class GenMyPyVisitor(visitor.AsdlVisitor):
         self.Emit('', depth)
 
         # the base class, e.g. 'oil_cmd'
-        self.Emit('class %s_t(pybase.CompoundObj):' % sum_name, depth)
+        bases = ['pybase.CompoundObj']
+        bases.extend(sum.deriving)
+        self.Emit('class %s_t(%s):' % (sum_name, ", ".join(bases)), depth)
         self.Indent()
         depth = self.current_depth
 

--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -222,6 +222,13 @@ module runtime
 
   # Hay "first word" namespace
   HayNode = (Dict[str, HayNode] children)
+
+  control_flow =
+    Break(Token keyword, int levels)
+  | Continue(Token keyword, int levels)
+  | Return(Token keyword, int code)
+  | Retval(Token keyword, value val)
+  deriving [Exception]
 }
 
 # vim: sw=2

--- a/core/vm.py
+++ b/core/vm.py
@@ -1,7 +1,6 @@
 """vm.py: Library for executing shell."""
 from __future__ import print_function
 
-from _devbuild.gen.id_kind_asdl import Id
 from _devbuild.gen.runtime_asdl import (CommandStatus, StatusArray, flow_e,
                                         flow_t, control_flow, control_flow_t,
                                         control_flow_e)

--- a/osh/builtin_meta.py
+++ b/osh/builtin_meta.py
@@ -5,7 +5,7 @@ builtin_meta.py - Builtins that call back into the interpreter.
 from __future__ import print_function
 
 from _devbuild.gen import arg_types
-from _devbuild.gen.runtime_asdl import cmd_value, CommandStatus
+from _devbuild.gen.runtime_asdl import cmd_value, CommandStatus, control_flow
 from _devbuild.gen.syntax_asdl import source, loc
 from core import alloc
 from core import dev
@@ -128,11 +128,8 @@ class Source(vm._Builtin):
                                     c_parser,
                                     self.errfmt,
                                     cmd_flags=cmd_eval.RaiseControlFlow)
-                            except vm.IntControlFlow as e:
-                                if e.IsReturn():
-                                    status = e.StatusCode()
-                                else:
-                                    raise
+                            except control_flow.Return as e:
+                                status = vm.ControlFlowStatusCode(e)
 
         return status
 


### PR DESCRIPTION
We can now make asdl types derive arbitrarily like so:

```asdl
module runtime {
  control_flow =
    Break(int levels)
  | Return(int code)
  deriving [Exception]
}
```

Now we are able to declare the `ControlFlow` exception type in ASDL. This will make it easier to add more control flow types such as `error ('...')`. It also makes `ControlFlow` variant handling logic more uniform with other ASDL types.