### PR TITLE
word_parse.py: parse_backslash (errors + hinting questions)

### DIFF
--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style string literal", tok)
+                    p_die("Invalid char escape in C-style string literal. Literal: '\\\\' (parse_backslash)", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string",
+                                "Invalid char escape in double quoted string. Literal: '\\\\' (parse_backslash)",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die('Invalid char escape (parse_backslash)',
+                    p_die("Invalid char escape. Literal: '\\\\' (parse_backslash)',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style string literal. Use '\\\\' to get \\ (parse_backslash).", tok)
+                    p_die('Invalid char escape in C-style string literal. Use \\ to get \ (parse_backslash).', tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string. Use '\\\\' to get \\ (parse_backslash).",
+                                'Invalid char escape in double quoted string. Only \", \$, or \\ to get \ (parse_backslash).',
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die("Invalid char escape. Use '\\\\' to get \\ (parse_backslash).',
+                    p_die('Invalid char escape. Remove, or use \\ to get \ (parse_backslash).',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string literal (parse_backslash)\n\t Only allowed: \\\", \\$, or \\\\ to denote \\\n\t* use \\\\ to denote a \\ ?\n\t* (ysh) use "- ++ u'- or b'-literal instead?",
+                                "Invalid char escape in double quoted string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* (ysh) use \"- ++ u'- or b'-literals instead ?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style string literal. Only allowed literal: '\\\\' (parse_backslash)", tok)
+                    p_die("Invalid char escape in C-style string literal. Use '\\\\' to print \ (parse_backslash).", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string. Only allowed literal: '\\\\' (parse_backslash)",
+                                "Invalid char escape in double quoted string. Use '\\\\' to print \ (parse_backslash).",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die("Invalid char escape. Only allowed literal: '\\\\' (parse_backslash)',
+                    p_die("Invalid char escape. Use '\\\\' to print \ (parse_backslash).',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style $'-string literal (parse_backslash)\n\t* use \\\\ to denote a \\ ?\n\t* (ysh) use u'- or b'-literal instead ?", tok)
+                    p_die("Invalid char escape in C-style $'-string literal (parse_backslash)\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) use u'- or b'-literal instead ?\n\t* (ysh) concat r'- ++ u'- or b'-literals ?", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* (ysh) use \"- ++ u'- or b'-literals instead ?",
+                                "Invalid char escape in double quoted string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style string literal. Use '\\\\' to get \ (parse_backslash).", tok)
+                    p_die("Invalid char escape in C-style string literal. Use '\\\\' to get \\ (parse_backslash).", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string. Use '\\\\' to get \ (parse_backslash).",
+                                "Invalid char escape in double quoted string. Use '\\\\' to get \\ (parse_backslash).",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die("Invalid char escape. Use '\\\\' to get \ (parse_backslash).',
+                    p_die("Invalid char escape. Use '\\\\' to get \\ (parse_backslash).',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style string literal. Use '\\\\' to print \ (parse_backslash).", tok)
+                    p_die("Invalid char escape in C-style string literal. Use '\\\\' to get \ (parse_backslash).", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string. Use '\\\\' to print \ (parse_backslash).",
+                                "Invalid char escape in double quoted string. Use '\\\\' to get \ (parse_backslash).",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die("Invalid char escape. Use '\\\\' to print \ (parse_backslash).',
+                    p_die("Invalid char escape. Use '\\\\' to get \ (parse_backslash).',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style $'-string literal (parse_backslash)\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) use u'- or b'-literal instead ?\n\t* (ysh) concat r'- ++ u'- or b'-literals ?", tok)
+                    p_die("Invalid char escape in C-style $'-string literal (parse_backslash, no verbatims)\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) use u'- or b'-literal instead ?\n\t* (ysh) concat r'- ++ u'- or b'-literals ?", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in $variable expanding \"-string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
+                                "Invalid char escape in $variable expanding \"-string literal (parse_backslash, no verbatims)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die("Invalid char escape (parse_backslash)\n\t* remove \ ?\n\t* use \\\\ to denote a \\ ?\n\t* use \"raw\" '-string-literal ?\n\t* use \"interpreted\" $'-string-literal ?\n\t* (ysh) use \"raw\" r'-string-literal ?\n\t* (ysh) use \"interpreted\" u'- or b'-string-literal ?",
+                    p_die("Invalid char escape (parse_backslash, no verbatims, no quotings)\n\t* remove \ ?\n\t* use \\\\ to denote a \\ ?\n\t* use \"raw\" '-string-literal ?\n\t* use \"interpreted\" $'-string-literal ?\n\t* (ysh) use \"raw\" r'-string-literal ?\n\t* (ysh) use \"interpreted\" u'- or b'-string-literal ?",
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die('Invalid char escape in C-style string literal. Use \\\\ to get \ (parse_backslash).', tok)
+                    p_die('Invalid char escape in C-style string literal (parse_backslash).\n\t* \\\\ to denote \\ ?\n\t* use u\'- or b\'-literal ? (ysh)', tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                'Invalid char escape in double quoted string. Only \", \$, or \\\\ to get \ (parse_backslash).',
+                                'Invalid char escape in double quoted string literal (parse_backslash).\n\t Only allowed: \", \$, or \\\\ to denote \\\n\t* change to \\\\ to denote \\ ?\n\t* use u\'- or b\'-literal ? (ysh)',
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die('Invalid char escape. Remove, or use \\\\ to get \ (parse_backslash).',
+                    p_die('Invalid char escape (parse_backslash).\n\t* remove \ ?\n\t* use \\\\ to denote \\ ?\n\t* use \'- or r\'-string-literal ?',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
+                                "Invalid char escape in double quoted \"-string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted \"-string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
+                                "Invalid char escape in $variable expanding \"-string literal (parse_backslash)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in $variable expanding \"-string literal (parse_backslash, no verbatims)\n\tOnly allowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
+                                "Invalid char escape in \"-string literal (parse_backslash, no verbatims)\n\tAllowed: \\\", \\$, or \\\\ to denote \", $, or \\\n\t* use \\\\ to denote a \\ ?\n\t* 'chain'\"different\"$'literals' ?\n\t* (ysh) concat \"- ++ u'- or b'-literals ?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die('Invalid char escape in C-style string literal (parse_backslash).\n\t* \\\\ to denote \\ ?\n\t* use u\'- or b\'-literal ? (ysh)', tok)
+                    p_die("Invalid char escape in C-style $'-string literal (parse_backslash)\n\t* use \\\\ to denote a \\ ?\n\t* (ysh) use u'- or b'-literal instead ?", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                'Invalid char escape in double quoted string literal (parse_backslash).\n\t Only allowed: \", \$, or \\\\ to denote \\\n\t* change to \\\\ to denote \\ ?\n\t* use u\'- or b\'-literal ? (ysh)',
+                                "Invalid char escape in double quoted string literal (parse_backslash)\n\t Only allowed: \\\", \\$, or \\\\ to denote \\\n\t* use \\\\ to denote a \\ ?\n\t* (ysh) use "- ++ u'- or b'-literal instead?",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die('Invalid char escape (parse_backslash).\n\t* remove \ ?\n\t* use \\\\ to denote \\ ?\n\t* use \'- or r\'-string-literal ?',
+                    p_die("Invalid char escape (parse_backslash)\n\t* remove \ ?\n\t* use \\\\ to denote a \\ ?\n\t* use \"raw\" '-string-literal ?\n\t* use \"interpreted\" $'-string-literal ?\n\t* (ysh) use \"raw\" r'-string-literal ?\n\t* (ysh) use \"interpreted\" u'- or b'-string-literal ?",
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die('Invalid char escape in C-style string literal. Use \\ to get \ (parse_backslash).', tok)
+                    p_die('Invalid char escape in C-style string literal. Use \\\\ to get \ (parse_backslash).', tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                'Invalid char escape in double quoted string. Only \", \$, or \\ to get \ (parse_backslash).',
+                                'Invalid char escape in double quoted string. Only \", \$, or \\\\ to get \ (parse_backslash).',
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die('Invalid char escape. Remove, or use \\ to get \ (parse_backslash).',
+                    p_die('Invalid char escape. Remove, or use \\\\ to get \ (parse_backslash).',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -667,7 +667,7 @@ class WordParser(WordEmitter):
 
                 # x = $'\z' is disallowed; ditto for echo $'\z' if shopt -u parse_backslash
                 if is_ysh_expr or not self.parse_opts.parse_backslash():
-                    p_die("Invalid char escape in C-style string literal. Literal: '\\\\' (parse_backslash)", tok)
+                    p_die("Invalid char escape in C-style string literal. Only allowed literal: '\\\\' (parse_backslash)", tok)
 
                 tokens.append(tok)
 
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
                         if (is_ysh_expr or
                                 not self.parse_opts.parse_backslash()):
                             p_die(
-                                "Invalid char escape in double quoted string. Literal: '\\\\' (parse_backslash)",
+                                "Invalid char escape in double quoted string. Only allowed literal: '\\\\' (parse_backslash)",
                                 self.cur_token)
                     elif self.token_type == Id.Lit_Dollar:
                         if is_ysh_expr or not self.parse_opts.parse_dollar():
@@ -1611,7 +1611,7 @@ class WordParser(WordEmitter):
             ch = lexer.TokenSliceLeft(tok, 1)
             if not self.parse_opts.parse_backslash():
                 if not pyutil.IsValidCharEscape(ch):
-                    p_die("Invalid char escape. Literal: '\\\\' (parse_backslash)',
+                    p_die("Invalid char escape. Only allowed literal: '\\\\' (parse_backslash)',
                           self.cur_token)
 
             part = word_part.EscapedLiteral(self.cur_token,


### PR DESCRIPTION
This is to provide consistent short error messages, and adds minimal hinting questions for context and **immediate help-on-error**.

Note how the messages even improve more once `parse_backslash` gets renamed into `strict_backslash_escape`.

Example error messaage:
```
Invalid char escape in "-string literal (parse_backslash, no verbatims)
       Allowed: \", \$, or \\ to denote ", $, or \
       * use \\ to denote a \ ?
       * 'chain'"different"$'literals' ?
       * (ysh) concat "- ++ u'- or b'-literals ?
```