### PR TITLE
FIX: Correctly handle the case in Proc args binding when both  typed positional varargs and block arg are present

### DIFF
--- a/spec/ysh-proc.test.sh
+++ b/spec/ysh-proc.test.sh
@@ -322,7 +322,6 @@ proc doIt(;...args) {
     var a = args[0]
     echo $a
     var argsRest = args[1:]
-    # call argsRest->append(blk)
     doIt (...argsRest)
   }
 }

--- a/spec/ysh-proc.test.sh
+++ b/spec/ysh-proc.test.sh
@@ -292,6 +292,8 @@ brace
 ## END
 
 #### Test varargs and blocks
+shopt --set parse_proc
+
 proc DUMP(...a;...b;...c; d) {
   echo @a
   echo @b

--- a/spec/ysh-proc.test.sh
+++ b/spec/ysh-proc.test.sh
@@ -311,3 +311,40 @@ d e f
 0 - h - i
 1 - j - k
 ## END
+
+#### mixing typed positional varargs and blocks
+shopt --set ysh:upgrade
+
+proc doIt(;...args) {
+  if (len(args) === 1) {
+    eval (args[0])
+  } else {
+    var a = args[0]
+    echo $a
+    var argsRest = args[1:]
+    # call argsRest->append(blk)
+    doIt (...argsRest)
+  }
+}
+
+# all of below work. 
+doIt (1, 2, 3) {
+  echo 4
+}
+
+doIt (1, 2, 3, ^(echo 4))
+
+doIt {
+  echo 1
+}
+## STDOUT:
+1
+2
+3
+4
+1
+2
+3
+4
+1
+## END

--- a/spec/ysh-proc.test.sh
+++ b/spec/ysh-proc.test.sh
@@ -291,3 +291,21 @@ loop
 brace
 ## END
 
+#### Test varargs and blocks
+proc DUMP(...a;...b;...c; d) {
+  echo @a
+  echo @b
+  for i, k, v in (c) {
+    echo "$i - $k - $v"
+  }
+  # TODO : figure out how to inspect blocks
+}
+DUMP a b c ('d', 'e', 'f', h = "i", j = "k") {
+  echo 0
+}
+## STDOUT:
+a b c
+d e f
+0 - h - i
+1 - j - k
+## END

--- a/spec/ysh-proc.test.sh
+++ b/spec/ysh-proc.test.sh
@@ -292,7 +292,7 @@ brace
 ## END
 
 #### Test varargs and blocks
-shopt --set parse_proc
+shopt --set ysh:upgrade
 
 proc DUMP(...a;...b;...c; d) {
   echo @a

--- a/ysh/func_proc.py
+++ b/ysh/func_proc.py
@@ -355,7 +355,7 @@ def _BindTyped(
             num_params += len(rest_val)
             mem.SetLocalName(lval, value.List(rest_val))
         else:
-            if num_args > num_params:
+            if num_args > num_params + (1 if block_param else 0):
                 # Too many arguments.
                 raise error.Expr(
                     "%r takes %d typed args, but got %d" %


### PR DESCRIPTION
Continuation of https://github.com/oilshell/oil/pull/1893. Fixes https://github.com/oilshell/oil/issues/1892, maybe fixes https://github.com/oilshell/oil/issues/1849 .