### PR TITLE
[builtins/dict] add -> erase() method

### DIFF
--- a/builtin/method_dict.py
+++ b/builtin/method_dict.py
@@ -6,6 +6,7 @@ from _devbuild.gen.value_asdl import (value, value_t)
 
 from core import vm
 from frontend import typed_args
+from mycpp import mylib
 from mycpp.mylib import log
 
 from typing import List
@@ -43,3 +44,20 @@ class Values(vm._Callable):
 
         values = dictionary.values()  # type: List[value_t]
         return value.List(values)
+
+
+class Erase(vm._Callable):
+
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def Call(self, rd):
+        # type: (typed_args.Reader) -> value_t
+
+        dictionary = rd.PosDict()
+        key = rd.PosStr()
+        rd.Done()
+
+        mylib.dict_erase(dictionary, key)
+        return value.Null

--- a/core/shell.py
+++ b/core/shell.py
@@ -744,7 +744,7 @@ def Main(
     }
     methods[value_e.Dict] = {
         'get': None,  # doesn't raise an error
-        'erase': None,  # ensures it doesn't exist
+        'erase': method_dict.Erase(),
         'keys': method_dict.Keys(),
         'values': method_dict.Values(),
 

--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -343,7 +343,7 @@ Similar to `keys()`, but returns the values of the dictionary.
 
 ### erase()
 
-Accepts a key and deletes the relevant key-value pair. The method is idempotent.
+Ensures that the given key does not exist in the dictionary.
 
     var book = {
       title: "The Histories",
@@ -352,6 +352,11 @@ Accepts a key and deletes the relevant key-value pair. The method is idempotent.
     = book
     # => (Dict)   {title: "The Histories", author: "Herodotus"}
 
+    call book->erase("author")
+    = book
+    # => (Dict)   {title: "The Histories"}
+
+    # repeating the erase call does not cause an error
     call book->erase("author")
     = book
     # => (Dict)   {title: "The Histories"}

--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -343,6 +343,19 @@ Similar to `keys()`, but returns the values of the dictionary.
 
 ### erase()
 
+Accepts a key and deletes the relevant key-value pair. The method is idempotent.
+
+    var book = {
+      title: "The Histories",
+      author: "Herodotus",
+    }
+    = book
+    # => (Dict)   {title: "The Histories", author: "Herodotus"}
+
+    call book->erase("author")
+    = book
+    # => (Dict)   {title: "The Histories"}
+
 ### inc()
 
 ### accum()

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2223,7 +2223,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             else:
                 # del mydict[mykey] raises KeyError, which we don't want
                 raise AssertionError(
-                    'Use mylib.maybe_remove(d, key) instead of del d[key]')
+                    'Use mylib.dict_erase(d, key) instead of del d[key]')
 
             self.def_write(';\n')
 

--- a/spec/ysh-methods.test.sh
+++ b/spec/ysh-methods.test.sh
@@ -397,8 +397,12 @@ pp line (en2fr => values())
 var book = {title: "The Histories", author: "Herodotus"}
 call book->erase("author")
 pp line (book)
+# confirm method is idempotent
+call book->erase("author")
+pp line (book)
 ## status: 0
 ## STDOUT:
+(Dict)   {"title":"The Histories"}
 (Dict)   {"title":"The Histories"}
 ## END
 

--- a/spec/ysh-methods.test.sh
+++ b/spec/ysh-methods.test.sh
@@ -393,6 +393,15 @@ pp line (en2fr => values())
 (List)   ["bonjour","ami","chat"]
 ## END
 
+#### Dict -> erase()
+var book = {title: "The Histories", author: "Herodotus"}
+call book->erase("author")
+pp line (book)
+## status: 0
+## STDOUT:
+(Dict)   {"title":"The Histories"}
+## END
+
 #### Separation of -> attr and () calling
 const check = "abc" => startsWith
 pp line (check("a"))


### PR DESCRIPTION
An oddity is that `erase` works with both `->` and `=>` despite only mutating, not transforming. But this behaviour matches other Dict and List methods, so the implementations are at least consistent with each other.