### PR TITLE
[WIP] Fix mycpp List::Pop(int)

### DIFF
--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -342,7 +342,7 @@ T List<T>::pop(int i) {
   len_--;
 
   // Shift everything by one
-  memmove(slab_->items_ + i, slab_->items_ + (i + 1), len_ * sizeof(T));
+  memmove(slab_->items_ + i, slab_->items_ + (i + 1), (len_ - i) * sizeof(T));
 
   /*
   for (int j = 0; j < len_; j++) {

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -463,7 +463,7 @@ TEST test_list_remove() {
   PASS();
 }
 
-TEST test_list_pop() {
+TEST test_list_pop_mem_safe() {
   auto l = NewList<int>();
 
   // List::pop(int) had a memory bug where it would buffer overflow due to a
@@ -473,7 +473,7 @@ TEST test_list_pop() {
     l->append(i);
   }
 
-  l->pop(15);
+  l->pop(15);  // This would cause a buffer overflow
 
   PASS();
 }
@@ -498,7 +498,8 @@ int main(int argc, char** argv) {
   RUN_TEST(test_list_copy);
   RUN_TEST(test_list_sort);
   RUN_TEST(test_list_remove);
-  RUN_TEST(test_list_pop);
+
+  RUN_TEST(test_list_pop_mem_safe);
 
   gHeap.CleanProcessExit();
 

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -463,6 +463,21 @@ TEST test_list_remove() {
   PASS();
 }
 
+TEST test_list_pop() {
+  auto l = NewList<int>();
+
+  // List::pop(int) had a memory bug where it would buffer overflow due to a
+  // mistake when calling memmove. To reproduce, the list had to be at least 16
+  // items long, otherwise ASAN will not catch the error.
+  for (int i = 0; i < 16; ++i) {
+    l->append(i);
+  }
+
+  l->pop(15);
+
+  PASS();
+}
+
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv) {
@@ -483,6 +498,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_list_copy);
   RUN_TEST(test_list_sort);
   RUN_TEST(test_list_remove);
+  RUN_TEST(test_list_pop);
 
   gHeap.CleanProcessExit();
 


### PR DESCRIPTION
Fix for `List::Pop(int i)` for any non-zero positive `i`.

Found in #2028.