### PR TITLE
Fix pp tabular

### DIFF
--- a/data_lang/pretty.asdl
+++ b/data_lang/pretty.asdl
@@ -22,6 +22,7 @@ module pretty
     | Concat(List[MeasuredDoc] mdocs)
     | Group(MeasuredDoc mdoc)
     | IfFlat(MeasuredDoc flat_mdoc, MeasuredDoc nonflat_mdoc)
+    | Flat(MeasuredDoc mdoc)
   
   # Used internally while pretty printing.
   # See comments in PrettyPrinter._PrintDoc.

--- a/data_lang/pretty.py
+++ b/data_lang/pretty.py
@@ -76,6 +76,8 @@ maximum line width.
 #
 # IfFlat(a, b) prints a if in flat mode or b otherwise.
 #
+# Flat(a) prints a in flat mode. You should generally not need to use it.
+#
 # ~ Measures ~
 #
 # The algorithm used here is close to the one originally described by Wadler,
@@ -226,6 +228,11 @@ def _IfFlat(flat_mdoc, nonflat_mdoc):
     return MeasuredDoc(
         doc.IfFlat(flat_mdoc, nonflat_mdoc),
         Measure(flat_mdoc.measure.flat, nonflat_mdoc.measure.nonflat))
+
+def _Flat(mdoc):
+    # type: (MeasuredDoc) -> MeasuredDoc
+    """Prints `mdoc` in flat mode."""
+    return MeasuredDoc(doc.Flat(mdoc), _FlattenMeasure(mdoc.measure))
 
 
 ###################
@@ -381,6 +388,11 @@ class PrettyPrinter(object):
                     fragments.append(
                         DocFragment(subdoc, frag.indent, frag.is_flat,
                                     frag.measure))
+
+                elif case(doc_e.Flat):
+                    flat_doc = cast(doc.Flat, frag.mdoc.doc)
+                    fragments.append(
+                        DocFragment(flat_doc.mdoc, frag.indent, True, frag.measure))
 
 
 ################
@@ -559,7 +571,7 @@ class _DocConstructor:
         if max_flat_len + sep_width + 1 <= self.max_tabular_width:
             tabular_seq = []  # type: List[MeasuredDoc]
             for i, item in enumerate(items):
-                tabular_seq.append(item)
+                tabular_seq.append(_Flat(item))
                 if i != len(items) - 1:
                     padding = max_flat_len - item.measure.flat + 1
                     tabular_seq.append(_Text(sep))

--- a/data_lang/pretty.py
+++ b/data_lang/pretty.py
@@ -229,6 +229,7 @@ def _IfFlat(flat_mdoc, nonflat_mdoc):
         doc.IfFlat(flat_mdoc, nonflat_mdoc),
         Measure(flat_mdoc.measure.flat, nonflat_mdoc.measure.nonflat))
 
+
 def _Flat(mdoc):
     # type: (MeasuredDoc) -> MeasuredDoc
     """Prints `mdoc` in flat mode."""
@@ -392,7 +393,8 @@ class PrettyPrinter(object):
                 elif case(doc_e.Flat):
                     flat_doc = cast(doc.Flat, frag.mdoc.doc)
                     fragments.append(
-                        DocFragment(flat_doc.mdoc, frag.indent, True, frag.measure))
+                        DocFragment(flat_doc.mdoc, frag.indent, True,
+                                    frag.measure))
 
 
 ################

--- a/data_lang/pretty_test.txt
+++ b/data_lang/pretty_test.txt
@@ -99,10 +99,8 @@ Expect
 >     [
 >         100, 200,
 >         300
->     ], [
->         100, 200,
->         300
->     ]
+>     ],
+>     [100, 200, 300]
 > ]
 
 Width  > 11
@@ -112,7 +110,8 @@ Expect
 >         100,
 >         200,
 >         300
->     ], [
+>     ],
+>     [
 >         100,
 >         200,
 >         300
@@ -261,6 +260,16 @@ Expect
 >     "aaaaaaaaaaaaaaaaaaa",
 >     "bbbbbbbbbbbbbbbbbbbbb",
 >     "cccccccccccccccccccc"
+> ]
+
+# Last element in tabular alignment wants to split across multiple lines,
+# but should not.
+Input > ["aaaaaaa", "bbbbbbb", "ccccccc", {"d": "k"}]
+Width > 40
+Expect
+> [
+>     "aaaaaaa", "bbbbbbb", "ccccccc",
+>     {d: "k"}
 > ]
 
 
@@ -415,9 +424,8 @@ Expect
 >         stringy_primitives: "string"
 >     },
 >     compounds: [
->         [1, 2, 3],        {
->             dict: "ionary"
->         }
+>         [1, 2, 3],
+>         {dict: "ionary"}
 >     ],
 >     "variety-pack": [
 >         null,


### PR DESCRIPTION
Fix a bug in pretty printing tabular alignment (it must force elements to be flat).

The new test case is robust against differing values of `_DEFAULT_MAX_TABULAR_WIDTH`.