### PR TITLE
[builtins] Add Dict => get() method

### DIFF
--- a/builtin/method_dict.py
+++ b/builtin/method_dict.py
@@ -61,3 +61,20 @@ class Erase(vm._Callable):
 
         mylib.dict_erase(dictionary, key)
         return value.Null
+
+
+class Get(vm._Callable):
+
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def Call(self, rd):
+        # type: (typed_args.Reader) -> value_t
+
+        dictionary = rd.PosDict()
+        key = rd.PosStr()
+        default_value = rd.PosValue()
+        rd.Done()
+
+        return dictionary.get(key, default_value)

--- a/core/shell.py
+++ b/core/shell.py
@@ -745,7 +745,7 @@ def Main(
         'fullMatch': None,
     }
     methods[value_e.Dict] = {
-        'get': None,  # doesn't raise an error
+        'get': method_dict.Get(),
         'erase': method_dict.Erase(),
         'keys': method_dict.Keys(),
         'values': method_dict.Values(),

--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -341,6 +341,21 @@ Similar to `keys()`, but returns the values of the dictionary.
 
 ### get()
 
+Return value for given key, falling back to the default value if the key 
+doesn't exist. Default is required.
+
+    var book = {
+      title: "Hitchhiker's Guide",
+      published: 1979,
+    }
+    var published = book => get("published", null)
+    = published
+    # => (Int 1979)
+
+    var author = book => get("author", "???")
+    = author
+    # => (Str "???")
+
 ### erase()
 
 Ensures that the given key does not exist in the dictionary.

--- a/spec/ysh-methods.test.sh
+++ b/spec/ysh-methods.test.sh
@@ -406,6 +406,18 @@ pp test_ (book)
 (Dict)   {"title":"The Histories"}
 ## END
 
+#### Dict -> get()
+var book = {title: "Hitchhiker's Guide", published: 1979}
+pp test_ (book => get("title", ""))
+pp test_ (book => get("published", 0))
+pp test_ (book => get("author", ""))
+## status: 0
+## STDOUT:
+(Str)   "Hitchhiker's Guide"
+(Int)   1979
+(Str)   ""
+## END
+
 #### Separation of -> attr and () calling
 const check = "abc" => startsWith
 pp test_ (check("a"))


### PR DESCRIPTION
Use verbose variable name `default_value` because `default` breaks mycpp, which seems to confuse it for the default case in a switch statement. (Going by an initial read of the errors. I haven't dug into it.)

This implementation makes the default value a required argument, but I can make it optional (more Pythonic) if preferred.

Still a bit confused about `=>` vs `->` because all `Dict` methods, including this one, seem to work with both.