### PR TITLE
Don't push a new frame in `eval ()`

### DIFF
--- a/builtin/method_str.py
+++ b/builtin/method_str.py
@@ -459,8 +459,7 @@ class Replace(vm._Callable):
                     s = subst_str.s
                 if subst_expr:
                     with state.ctx_Eval(self.mem, arg0, argv, named_vars):
-                        s = self.EvalSubstExpr(subst_expr,
-                                               rd.LeftParenToken())
+                        s = self.EvalSubstExpr(subst_expr, rd.LeftParenToken())
                 assert s is not None
 
                 start = indices[0]

--- a/builtin/method_str.py
+++ b/builtin/method_str.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from _devbuild.gen.syntax_asdl import loc_t
 from _devbuild.gen.value_asdl import (value, value_e, value_t, eggex_ops,
                                       eggex_ops_t, RegexMatch)
-from builtin import pure_ysh
 from core import error
 from core import state
 from core import vm
@@ -20,7 +19,7 @@ from ysh import val_ops
 import libc
 from libc import REG_NOTBOL
 
-from typing import cast, List, Tuple
+from typing import cast, Dict, List, Tuple
 
 _ = log
 
@@ -423,7 +422,7 @@ class Replace(vm._Callable):
                 # Collect captures
                 arg0 = None  # type: str
                 argv = []  # type: List[str]
-                named_vars = []  # type: List[Tuple[str, value_t]]
+                named_vars = {}  # type: Dict[str, value_t]
                 num_groups = len(indices) / 2
                 for group in xrange(num_groups):
                     start = indices[2 * group]
@@ -454,15 +453,14 @@ class Replace(vm._Callable):
                     if group != 0:
                         name = eggex_val.capture_names[group - 2]
                         if name is not None:
-                            named_vars.append((name, val))
+                            named_vars[name] = val
 
                 if subst_str:
                     s = subst_str.s
                 if subst_expr:
-                    with state.ctx_Eval(self.mem, arg0, argv, None):
-                        with pure_ysh.ctx_Shvar(self.mem, named_vars):
-                            s = self.EvalSubstExpr(subst_expr,
-                                                   rd.LeftParenToken())
+                    with state.ctx_Eval(self.mem, arg0, argv, named_vars):
+                        s = self.EvalSubstExpr(subst_expr,
+                                               rd.LeftParenToken())
                 assert s is not None
 
                 start = indices[0]

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -3,61 +3,22 @@ builtin/pure_ysh.py - YSH builtins that don't do I/O.
 """
 from __future__ import print_function
 
-from _devbuild.gen.runtime_asdl import (cmd_value, scope_e)
+from _devbuild.gen.runtime_asdl import cmd_value
 from _devbuild.gen.syntax_asdl import command_t, loc, loc_t
-from _devbuild.gen.value_asdl import (value, value_e, value_t, LeftName)
+from _devbuild.gen.value_asdl import value, value_e, value_t
 from core import error
 from core import state
 from core import vm
 from frontend import flag_util
-from frontend import location
 from frontend import typed_args
 from mycpp import mylib
 from mycpp.mylib import tagswitch
 
-from typing import TYPE_CHECKING, cast, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, cast, Any, Dict, List
 
 if TYPE_CHECKING:
     from display import ui
     from osh.cmd_eval import CommandEvaluator
-
-
-class ctx_Shvar(object):
-    """For shvar LANG=C _ESCAPER=posix-sh-word _DIALECT=ninja."""
-
-    def __init__(self, mem, pairs):
-        # type: (state.Mem, List[Tuple[str, value_t]]) -> None
-        #log('pairs %s', pairs)
-        self.mem = mem
-        self.restore = []  # type: List[Tuple[LeftName, value_t]]
-        self._Push(pairs)
-
-    def __enter__(self):
-        # type: () -> None
-        pass
-
-    def __exit__(self, type, value, traceback):
-        # type: (Any, Any, Any) -> None
-        self._Pop()
-
-    # Note: _Push and _Pop are separate methods because the C++ translation
-    # doesn't like when they are inline in __init__ and __exit__.
-    def _Push(self, pairs):
-        # type: (List[Tuple[str, value_t]]) -> None
-        for name, v in pairs:
-            lval = location.LName(name)
-            # LocalOnly because we are only overwriting the current scope
-            old_val = self.mem.GetValue(name, scope_e.LocalOnly)
-            self.restore.append((lval, old_val))
-            self.mem.SetNamed(lval, v, scope_e.LocalOnly)
-
-    def _Pop(self):
-        # type: () -> None
-        for lval, old_val in self.restore:
-            if old_val.tag() == value_e.Undef:
-                self.mem.Unset(lval, scope_e.LocalOnly)
-            else:
-                self.mem.SetNamed(lval, old_val, scope_e.LocalOnly)
 
 
 class Shvar(vm._Builtin):
@@ -80,7 +41,7 @@ class Shvar(vm._Builtin):
             # But should there be a whitelist?
             raise error.Usage('expected a block', loc.Missing)
 
-        pairs = []  # type: List[Tuple[str, value_t]]
+        vars = {} # type: Dict[str, value_t]
         args, arg_locs = arg_r.Rest2()
         if len(args) == 0:
             raise error.Usage('Expected name=value', loc.Missing)
@@ -90,13 +51,13 @@ class Shvar(vm._Builtin):
             if s is None:
                 raise error.Usage('Expected name=value', arg_locs[i])
             v = value.Str(s)  # type: value_t
-            pairs.append((name, v))
+            vars[name] = v
 
             # Important fix: shvar PATH='' { } must make all binaries invisible
             if name == 'PATH':
                 self.search_path.ClearCache()
 
-        with ctx_Shvar(self.mem, pairs):
+        with state.ctx_Eval(self.mem, None, None, vars):
             unused = self.cmd_ev.EvalCommand(cmd)
 
         return 0

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -12,7 +12,7 @@ from core import vm
 from frontend import flag_util
 from frontend import typed_args
 from mycpp import mylib
-from mycpp.mylib import tagswitch
+from mycpp.mylib import tagswitch, NewDict
 
 from typing import TYPE_CHECKING, cast, Any, Dict, List
 
@@ -41,7 +41,7 @@ class Shvar(vm._Builtin):
             # But should there be a whitelist?
             raise error.Usage('expected a block', loc.Missing)
 
-        vars = {}  # type: Dict[str, value_t]
+        vars = NewDict()  # type: Dict[str, value_t]
         args, arg_locs = arg_r.Rest2()
         if len(args) == 0:
             raise error.Usage('Expected name=value', loc.Missing)

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -41,7 +41,7 @@ class Shvar(vm._Builtin):
             # But should there be a whitelist?
             raise error.Usage('expected a block', loc.Missing)
 
-        vars = {} # type: Dict[str, value_t]
+        vars = {}  # type: Dict[str, value_t]
         args, arg_locs = arg_r.Rest2()
         if len(args) == 0:
             raise error.Usage('Expected name=value', loc.Missing)

--- a/core/state.py
+++ b/core/state.py
@@ -1149,11 +1149,7 @@ class ctx_Eval(object):
 
         if vars is not None:
             self.restore = []  # type: List[Tuple[LeftName, value_t]]
-
-            pairs = []  # type: List[Tuple[str, value_t]]
-            for name in vars:
-                pairs.append((name, vars[name]))
-            self._Push(pairs)  # TODO: just use the `vars` dict directly
+            self._Push(vars)
 
     def __enter__(self):
         # type: () -> None
@@ -1172,14 +1168,14 @@ class ctx_Eval(object):
 
     # Note: _Push and _Pop are separate methods because the C++ translation
     # doesn't like when they are inline in __init__ and __exit__.
-    def _Push(self, pairs):
-        # type: (List[Tuple[str, value_t]]) -> None
-        for name, v in pairs:
+    def _Push(self, vars):
+        # type: (Dict[str, value_t]) -> None
+        for name in vars:
             lval = location.LName(name)
             # LocalOnly because we are only overwriting the current scope
             old_val = self.mem.GetValue(name, scope_e.LocalOnly)
             self.restore.append((lval, old_val))
-            self.mem.SetNamed(lval, v, scope_e.LocalOnly)
+            self.mem.SetNamed(lval, vars[name], scope_e.LocalOnly)
 
     def _Pop(self):
         # type: () -> None

--- a/core/state.py
+++ b/core/state.py
@@ -1150,7 +1150,7 @@ class ctx_Eval(object):
         if vars is not None:
             self.restore = []  # type: List[Tuple[LeftName, value_t]]
 
-            pairs = []  # type: List[Tuple[LeftName, value_t]]
+            pairs = []  # type: List[Tuple[str, value_t]]
             for name in vars:
                 pairs.append((name, vars[name]))
             self._Push(pairs)  # TODO: just use the `vars` dict directly

--- a/core/state.py
+++ b/core/state.py
@@ -1128,7 +1128,7 @@ def _MakeArgvCell(argv):
 
 
 class ctx_Eval(object):
-    """Push temporary variable frame and override $0, $1, $2, etc."""
+    """Push temporary set of variables, $0, $1, $2, etc."""
 
     def __init__(self, mem, dollar0, pos_args, vars):
         # type: (Mem, Optional[str], Optional[List[str]], Optional[Dict[str, value_t]]) -> None
@@ -1148,11 +1148,12 @@ class ctx_Eval(object):
             mem.argv_stack.append(_ArgFrame(pos_args))
 
         if vars is not None:
-            frame = {}  # type: Dict[str, Cell]
-            for name in vars:
-                frame[name] = Cell(False, False, False, vars[name])
+            self.restore = []  # type: List[Tuple[LeftName, value_t]]
 
-            mem.var_stack.append(frame)
+            pairs = []  # type: List[Tuple[LeftName, value_t]]
+            for name in vars:
+                pairs.append((name, vars[name]))
+            self._Push(pairs)  # TODO: just use the `vars` dict directly
 
     def __enter__(self):
         # type: () -> None
@@ -1161,13 +1162,32 @@ class ctx_Eval(object):
     def __exit__(self, type, value_, traceback):
         # type: (Any, Any, Any) -> None
         if self.vars is not None:
-            self.mem.var_stack.pop()
+            self._Pop()
 
         if self.pos_args is not None:
             self.mem.argv_stack.pop()
 
         if self.dollar0 is not None:
             self.mem.SetLocalName(self.dollar0_lval, value.Undef)
+
+    # Note: _Push and _Pop are separate methods because the C++ translation
+    # doesn't like when they are inline in __init__ and __exit__.
+    def _Push(self, pairs):
+        # type: (List[Tuple[str, value_t]]) -> None
+        for name, v in pairs:
+            lval = location.LName(name)
+            # LocalOnly because we are only overwriting the current scope
+            old_val = self.mem.GetValue(name, scope_e.LocalOnly)
+            self.restore.append((lval, old_val))
+            self.mem.SetNamed(lval, v, scope_e.LocalOnly)
+
+    def _Pop(self):
+        # type: () -> None
+        for lval, old_val in self.restore:
+            if old_val.tag() == value_e.Undef:
+                self.mem.Unset(lval, scope_e.LocalOnly)
+            else:
+                self.mem.SetNamed(lval, old_val, scope_e.LocalOnly)
 
 
 class Mem(object):

--- a/spec/ysh-builtin-eval.test.sh
+++ b/spec/ysh-builtin-eval.test.sh
@@ -278,6 +278,26 @@ pp test_ (vars)
 eval (^(true), pos_args=[1, 2, 3])
 ## status: 3
 
+#### eval with vars follows same scoping as without
+proc local-scope {
+  var myVar = "foo"
+  eval (^(echo $myVar), vars={ someOtherVar: "bar" })
+  eval (^(echo $myVar))
+}
+
+# In global scope
+var myVar = "baz"
+eval (^(echo $myVar), vars={ someOtherVar: "bar" })
+eval (^(echo $myVar))
+
+local-scope
+## STDOUT:
+baz
+baz
+foo
+foo
+## END
+
 #### eval 'mystring' vs. eval (myblock)
 
 eval 'echo plain'


### PR DESCRIPTION
This test captures the effect of this change:

```
#### eval with vars follows same scoping as without
proc local-scope {
  var myVar = "foo"
  eval (^(echo $myVar), vars={ someOtherVar: "bar" })
  eval (^(echo $myVar))
}

# In global scope
var myVar = "baz"
eval (^(echo $myVar), vars={ someOtherVar: "bar" })
eval (^(echo $myVar))

local-scope
## STDOUT:
baz
baz
foo
foo
## END
```