### PR TITLE
Fix issues in `Str => replace(eggex, *)`

### DIFF
--- a/builtin/method_str.py
+++ b/builtin/method_str.py
@@ -464,6 +464,12 @@ class Replace(vm._Callable):
 
                 start = indices[0]
                 end = indices[1]
+                if pos == end:
+                    raise error.Structured(
+                        3,
+                        "eggex should never match the empty string",
+                        rd.LeftParenToken())
+
                 parts.append(string[pos:start])  # Unmatched substring
                 parts.append(s)  # Replacement
                 pos = end  # Move to end of match

--- a/builtin/method_str.py
+++ b/builtin/method_str.py
@@ -405,6 +405,12 @@ class Replace(vm._Callable):
             return value.Str(result)
 
         if eggex_val:
+            if '\0' in string:
+                raise error.Structured(
+                    3,
+                    "cannot replace by eggex on a string with NUL bytes",
+                    rd.LeftParenToken())
+
             ere = regex_translate.AsPosixEre(eggex_val)
             cflags = regex_translate.LibcFlags(eggex_val.canonical_flags)
 

--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -143,6 +143,13 @@ The following matrix of signatures are supported by `replace()`:
     s => replace(eggex_val, subst_str)
     s => replace(eggex_val, subst_expr)
 
+Replacing by an `Eggex` has some limitations:
+
+- If a `search()` results in an empty string match, eg.
+  `'abc'.split(/ space* /)`, then we raise an error to avoid an infinite loop.
+- The string to replace on cannot contain NUL bytes because we use the libc
+  regex engine.
+
 ### startsWith()
 
 Checks if a string starts with a pattern, returning true if it does or false if

--- a/spec/ysh-regex-api.test.sh
+++ b/spec/ysh-regex-api.test.sh
@@ -827,3 +827,12 @@ write $[mystr => replace(/ ^ d+ ; reg_newline /, ^"[$0]")]
 [1]-2-3
 [4]-5
 ## END
+
+#### Str => replace(Eggex, *), guard against infinite loop
+shopt --set ysh:all
+
+var mystr = 'foo bar  baz'
+write $[mystr => replace(/ space* /, ' ')]
+## status: 3
+## STDOUT:
+## END

--- a/spec/ysh-regex-api.test.sh
+++ b/spec/ysh-regex-api.test.sh
@@ -836,3 +836,12 @@ write $[mystr => replace(/ space* /, ' ')]
 ## status: 3
 ## STDOUT:
 ## END
+
+#### Str => replace(Eggex, *), str cannot contain NUL bytes
+shopt --set ysh:all
+
+var mystr = b'foo bar  baz\y00'
+write $[mystr => replace(/ space+ /, ' ')]
+## status: 3
+## STDOUT:
+## END


### PR DESCRIPTION
This PR fixes the following issues:
- Infinite loop if we have a zero-width match
- Crash if the string contains a NUL byte