### PR TITLE
Correct misleading comment in `_build/oils.sh`

### DIFF
--- a/build/ninja_main.py
+++ b/build/ninja_main.py
@@ -105,8 +105,8 @@ def ShellFunctions(cc_sources, f, argv0):
 # Usage:
 #   _build/oils.sh COMPILER? VARIANT? SKIP_REBUILD?
 #
-#   COMPILER: 'cxx' for system compiler, or 'clang' [default cxx]
-#   VARIANT: 'dbg' or 'opt' [default dbg]
+#   COMPILER: 'cxx' for system compiler, 'clang' or custom one [default cxx]
+#   VARIANT: 'dbg' or 'opt' [default opt]
 #   SKIP_REBUILD: if non-empty, checks if the output exists before building
 
 . build/ninja-rules-cpp.sh


### PR DESCRIPTION
The header of this shell script states that the compiler can be either `cxx` or `clang` (but it can be anything) and it states that the default `VARIANT` is `'dbg'`, which is [disproved few lines below](https://github.com/oils-for-unix/oils/blob/master/build/ninja_main.py#L133):

```sh
  local variant=${2:-opt}    # default is optimized build
```