### PR TITLE
add mycpp-souffle translator

### DIFF
--- a/benchmarks/autoconf.sh
+++ b/benchmarks/autoconf.sh
@@ -44,6 +44,7 @@ cpython-configure-tasks() {
   for v in ${variants[@]}; do
     echo "${v}${TAB}_bin/cxx-$v/osh"
   done
+  echo "opt${TAB}_bin/cxx-opt/mycpp-souffle/osh"
 }
 
 cpython-setup() {
@@ -145,6 +146,7 @@ shell-tasks() {
   echo "bash${TAB}bash"
   echo "dash${TAB}dash"
   echo "osh${TAB}$REPO_ROOT/_bin/cxx-opt/osh"
+  echo "osh${TAB}$REPO_ROOT/_bin/cxx-opt/mycpp-souffle/osh"
 }
 
 measure-syscalls() {
@@ -524,6 +526,8 @@ fork-tasks() {
   # Hm this is noisy, but cxx-opt-sh does seem slower
   echo "osh${TAB}$REPO_ROOT/_bin/cxx-opt/osh"
   echo "osh${TAB}$REPO_ROOT/_bin/cxx-opt-sh/osh"
+  echo "osh${TAB}$REPO_ROOT/_bin/cxx-opt/mycpp-souffle/osh"
+  echo "osh${TAB}$REPO_ROOT/_bin/cxx-opt-sh/mycpp-souffle/osh"
 }
 
 measure-fork() {

--- a/benchmarks/common.sh
+++ b/benchmarks/common.sh
@@ -25,11 +25,14 @@ OIL_VERSION=$(head -n 1 oil-version.txt)
 readonly BENCHMARK_DATA_OILS=$PWD/../benchmark-data/src/oils-for-unix-$OIL_VERSION
 
 readonly OSH_CPP_NINJA_BUILD=_bin/cxx-opt/osh
+readonly OSH_SOUFFLE_CPP_NINJA_BUILD=_bin/cxx-opt/mycpp-souffle/osh
 
 readonly OSH_CPP_SH_BUILD=_bin/cxx-opt-sh/osh
+readonly OSH_SOUFFLE_CPP_SH_BUILD=_bin/cxx-opt-sh/mycpp-souffle/osh
 readonly YSH_CPP_SH_BUILD=_bin/cxx-opt-sh/ysh
 
 readonly OSH_CPP_BENCHMARK_DATA=$BENCHMARK_DATA_OILS/$OSH_CPP_SH_BUILD
+readonly OSH_SOUFFLE_CPP_BENCHMARK_DATA=$BENCHMARK_DATA_OILS/$OSH_SOUFFLE_CPP_SH_BUILD
 readonly YSH_CPP_BENCHMARK_DATA=$BENCHMARK_DATA_OILS/$YSH_CPP_SH_BUILD
 
 #

--- a/benchmarks/compute.sh
+++ b/benchmarks/compute.sh
@@ -411,7 +411,7 @@ soil-run() {
   mkdir -p $BASE_DIR
 
   # Test the one that's IN TREE, NOT in ../benchmark-data
-  local -a osh_bin=( $OSH_CPP_NINJA_BUILD _bin/cxx-opt+bumpleak/osh)
+  local -a osh_bin=( $OSH_CPP_NINJA_BUILD $OSH_SOUFFLE_CPP_NINJA_BUILD _bin/cxx-opt+bumpleak/osh)
   ninja "${osh_bin[@]}"
 
   local single_machine='no-host'

--- a/benchmarks/gc.sh
+++ b/benchmarks/gc.sh
@@ -114,9 +114,13 @@ print-tasks() {
     # these have trivial GC stats
     "_bin/cxx-opt/osh${TAB}mut+alloc"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc+free"
     # good GC stats
     "_bin/cxx-opt/osh${TAB}mut+alloc+free+gc"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free+gc+exit"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc+free+gc"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc+free+gc+exit"
   )
 
   if test -n "${TCMALLOC:-}"; then
@@ -183,6 +187,11 @@ print-cachegrind-tasks() {
     "_bin/cxx-opt/osh${TAB}mut+alloc+free"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free+gc"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free+gc+exit"
+
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc+free"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc+free+gc"
+    "_bin/cxx-opt/mycpp-souffle/osh${TAB}mut+alloc+free+gc+exit"
   )
 
   local id=0
@@ -389,10 +398,13 @@ build-binaries() {
     soil/cpp-tarball.sh build-like-ninja \
       opt{,+bumpleak,+bumproot,+bumpsmall,+nopool}
 
+    OILS_TRANSLATOR=mycpp-souffle soil/cpp-tarball.sh build-like-ninja opt
+
   else
 
     # Old Ninja build
     local -a bin=( _bin/cxx-opt{,+bumpleak,+bumproot,+bumpsmall,+nopool}/osh )
+    bin+=( _bin/cxx-opt/mycpp-souffle/osh )
 
     if test -n "${TCMALLOC:-}"; then
       bin+=( _bin/cxx-opt+tcmalloc/osh )

--- a/benchmarks/id.sh
+++ b/benchmarks/id.sh
@@ -159,6 +159,8 @@ _shell-id-hash() {
   # For OSH
   file=$src/git-commit-hash.txt
   test -f $file && cat $file
+  # XXX: Include shell path to help distinguish between versions of OSH
+  echo $src
 
   return 0
 }

--- a/benchmarks/osh-runtime.sh
+++ b/benchmarks/osh-runtime.sh
@@ -213,7 +213,8 @@ print-workloads() {
 
 print-tasks() {
   local host_name=$1  
-  local osh_native=$2
+  shift 1
+  local -a osh_native=( "$@" )
 
   if test -n "${QUICKLY:-}"; then
     workloads=(
@@ -226,7 +227,7 @@ print-tasks() {
     workloads=( "${ALL_WORKLOADS[@]}" )
   fi
 
-  for sh_path in bash dash bin/osh $osh_native; do
+  for sh_path in bash dash bin/osh "${osh_native[@]}"; do
     for workload in "${workloads[@]}"; do
       tsv-row $host_name $sh_path $workload
     done
@@ -311,9 +312,10 @@ measure() {
   ### For release and CI
   local host_name=$1  # 'no-host' or 'lenny'
   local raw_out_dir=$2  # _tmp/osh-runtime/$X or ../../benchmark-data/osh-runtime/$X
-  local osh_native=$3  # $OSH_CPP_NINJA_BUILD or $OSH_CPP_BENCHMARK_DATA
+  shift 2
+  local -a osh_native=( "$@" )  # $OSH_CPP_NINJA_BUILD or $OSH_CPP_BENCHMARK_DATA, etc...
 
-  print-tasks "$host_name" "$osh_native" \
+  print-tasks "$host_name" "${osh_native[@]}" \
     | run-tasks-wrapper "$host_name" "$raw_out_dir"
 }
 
@@ -492,7 +494,7 @@ soil-run() {
   extract
 
   # could add _bin/cxx-bumpleak/oils-for-unix, although sometimes it's slower
-  local -a osh_bin=( $OSH_CPP_NINJA_BUILD )
+  local -a osh_bin=( $OSH_CPP_NINJA_BUILD $OSH_SOUFFLE_CPP_NINJA_BUILD )
   ninja "${osh_bin[@]}"
 
   local single_machine='no-host'
@@ -509,7 +511,7 @@ soil-run() {
   local raw_out_dir="$BASE_DIR/raw.$host_job_id"
   mkdir -p $raw_out_dir $BASE_DIR/stage1
 
-  measure $single_machine $raw_out_dir $OSH_CPP_NINJA_BUILD
+  measure $single_machine $raw_out_dir $OSH_CPP_NINJA_BUILD $OSH_SOUFFLE_CPP_NINJA_BUILD
 
   # Trivial concatenation for 1 machine
   stage1 '' $single_machine

--- a/benchmarks/report.R
+++ b/benchmarks/report.R
@@ -65,6 +65,8 @@ GetOshLabel = function(shell_hash, prov_dir) {
       label = 'osh-ovm'
     } else if (length(grep('bin/osh', lines)) > 0) {
       label = 'osh-cpython'
+    } else if (length(grep('_bin/.*/mycpp-souffle/osh', lines)) > 0) {
+      label = 'osh-native-souffle'
     } else if (length(grep('_bin/.*/osh', lines)) > 0) {
       label = 'osh-native'
     } else {
@@ -78,6 +80,8 @@ GetOshLabel = function(shell_hash, prov_dir) {
 
 opt_suffix1 = '_bin/cxx-opt/osh'
 opt_suffix2 = '_bin/cxx-opt-sh/osh'
+opt_suffix3 = '_bin/cxx-opt/mycpp-souffle/osh'
+opt_suffix4 = '_bin/cxx-opt-sh/mycpp-souffle/osh'
 
 ShellLabels = function(shell_name, shell_hash, num_hosts) {
   ### Given 2 vectors, return a vector of readable labels.
@@ -104,6 +108,9 @@ ShellLabels = function(shell_name, shell_hash, num_hosts) {
     } else if (endsWith(sh, opt_suffix1) || endsWith(sh, opt_suffix2)) {
       label = 'opt/osh'
 
+    } else if (endsWith(sh, opt_suffix3) || endsWith(sh, opt_suffix4)) {
+      label = 'opt/osh-souffle'
+
     } else if (endsWith(sh, '_bin/cxx-opt+bumpleak/osh')) {
       label = 'bumpleak/osh'
 
@@ -127,6 +134,10 @@ ShellLabelFromPath = function(sh_path) {
     if (endsWith(sh, opt_suffix1) || endsWith(sh, opt_suffix2)) {
       # the opt binary is osh-native
       label = 'osh-native'
+
+	} else if (endsWith(sh, opt_suffix3) || endsWith(sh, opt_suffix4)) {
+      # the opt binary is osh-native
+      label = 'osh-native-souffle'
 
     } else if (endsWith(sh, '_bin/cxx-opt+bumpleak/osh')) {
       label = 'bumpleak/osh'
@@ -303,7 +314,7 @@ ParserReport = function(in_dir, out_dir) {
       arrange(host_label, num_lines) %>%
       mutate(osh_to_bash_ratio = `osh-native` / bash) %>% 
       select(c(host_label, bash, dash, mksh, zsh,
-               `osh-ovm`, `osh-cpython`, `osh-native`,
+               `osh-ovm`, `osh-cpython`, `osh-native`, `osh-native-souffle`,
                osh_to_bash_ratio, num_lines, filename, filename_HREF)) ->
       elapsed
 
@@ -317,7 +328,7 @@ ParserReport = function(in_dir, out_dir) {
       spread(key = shell_label, value = lines_per_ms) %>%
       arrange(host_label, num_lines) %>%
       select(c(host_label, bash, dash, mksh, zsh,
-               `osh-ovm`, `osh-cpython`, `osh-native`,
+               `osh-ovm`, `osh-cpython`, `osh-native`, `osh-native-souffle`,
                num_lines, filename, filename_HREF)) ->
       rate
 
@@ -331,7 +342,7 @@ ParserReport = function(in_dir, out_dir) {
       spread(key = shell_label, value = max_rss_MB) %>%
       arrange(host_label, num_lines) %>%
       select(c(host_label, bash, dash, mksh, zsh,
-               `osh-ovm`, `osh-cpython`, `osh-native`,
+               `osh-ovm`, `osh-cpython`, `osh-native`, `osh-native-souffle`,
                num_lines, filename, filename_HREF)) ->
       max_rss
 
@@ -350,7 +361,7 @@ ParserReport = function(in_dir, out_dir) {
       select(-c(irefs)) %>%
       spread(key = shell_label, value = thousand_irefs_per_line) %>%
       arrange(num_lines) %>%
-      select(c(bash, dash, mksh, `osh-native`,
+      select(c(bash, dash, mksh, `osh-native`, `osh-native-souffle`,
                num_lines, filename, filename_HREF)) ->
       instructions
 
@@ -537,7 +548,7 @@ RuntimeReport = function(in_dir, out_dir) {
     mutate(native_bash_ratio = `osh-native` / bash) %>%
     arrange(workload, host_name) %>%
     select(c(workload, host_name,
-             bash, dash, `osh-cpython`, `osh-native`,
+             bash, dash, `osh-cpython`, `osh-native`, `osh-native-souffle`,
              py_bash_ratio, native_bash_ratio)) ->
 
     elapsed
@@ -553,7 +564,7 @@ RuntimeReport = function(in_dir, out_dir) {
     mutate(native_bash_ratio = `osh-native` / bash) %>%
     arrange(workload, host_name) %>%
     select(c(workload, host_name,
-             bash, dash, `osh-cpython`, `osh-native`,
+             bash, dash, `osh-cpython`, `osh-native`, `osh-native-souffle`,
              py_bash_ratio, native_bash_ratio)) ->
     page_faults
 
@@ -568,7 +579,7 @@ RuntimeReport = function(in_dir, out_dir) {
     mutate(native_bash_ratio = `osh-native` / bash) %>%
     arrange(workload, host_name) %>%
     select(c(workload, host_name,
-             bash, dash, `osh-cpython`, `osh-native`,
+             bash, dash, `osh-cpython`, `osh-native`, `osh-native-souffle`,
              py_bash_ratio, native_bash_ratio)) ->
     max_rss
 
@@ -610,7 +621,7 @@ RuntimeReport = function(in_dir, out_dir) {
 
   # milliseconds don't need decimal digit
   precision = ColumnPrecision(list(bash = 0, dash = 0, `osh-cpython` = 0,
-                                   `osh-native` = 0, py_bash_ratio = 2,
+                                   `osh-native` = 0, `osh-native-souffle` = 0, py_bash_ratio = 2,
                                    native_bash_ratio = 2))
   writeTsv(elapsed, file.path(out_dir, 'elapsed'), precision)
   writeTsv(page_faults, file.path(out_dir, 'page_faults'), precision)

--- a/benchmarks/report_test.R
+++ b/benchmarks/report_test.R
@@ -18,6 +18,10 @@ TestShellLabels = function() {
   label = ShellLabels(shell_name, shell_hash, 1)
   checkEquals('opt/osh', label)
 
+  shell_name = 'yy/zz/_bin/cxx-opt/mycpp-souffle/osh'
+  label = ShellLabels(shell_name, shell_hash, 1)
+  checkEquals('opt/osh-souffle', label)
+
   shell_name = 'yy/zz/_bin/cxx-opt+bumpleak/osh'
   label = ShellLabels(shell_name, shell_hash, 1)
   checkEquals('bumpleak/osh', label)

--- a/bin/NINJA_subgraph.py
+++ b/bin/NINJA_subgraph.py
@@ -67,60 +67,75 @@ def NinjaGraph(ru):
     #
 
     for main_name in ('osh_eval', 'oils_for_unix'):
-        with open('_build/NINJA/bin.%s/translate.txt' % main_name) as f:
-            deps = [line.strip() for line in f]
+        for translator in ('mycpp', 'mycpp-souffle'):
+            with open('_build/NINJA/bin.%s/translate.txt' % main_name) as f:
+                deps = [line.strip() for line in f]
 
-        prefix = '_gen/bin/%s.mycpp' % main_name
-        outputs = [prefix + '.cc', prefix + '.h']
-        n.build(outputs,
-                'gen-oils-for-unix',
-                deps,
-                implicit=['_bin/shwrap/mycpp_main', RULES_PY],
-                variables=[('out_prefix', prefix), ('main_name', main_name),
-                           ('preamble', 'cpp/preamble.h')])
+            prefix = '_gen/bin/%s.%s' % (main_name, translator)
+            outputs = [prefix + '.cc', prefix + '.h']
 
-        if main_name == 'oils_for_unix':
-            # The main program!
-            bin_path = 'oils-for-unix'
-            symlinks = ['osh', 'ysh']
-        else:
-            symlinks = []
-            bin_path = None  # use default
+            variables = [
+                ('out_prefix', prefix),
+                ('main_name', main_name),
+                ('translator', translator),
+                ('preamble', 'cpp/preamble.h'),
+            ]
+            if translator == 'mycpp-souffle':
+                variables.append(('extra_mycpp_opts', '--minimize-stack-roots'))
 
-        ru.cc_binary(
-            '_gen/bin/%s.mycpp.cc' % main_name,
-            bin_path=bin_path,
-            symlinks=symlinks,
-            preprocessed=True,
-            matrix=(ninja_lib.COMPILERS_VARIANTS + ninja_lib.GC_PERF_VARIANTS +
-                    ninja_lib.OTHER_VARIANTS),
-            deps=[
-                '//bin/text_files',
-                '//cpp/core',
-                '//cpp/data_lang',
-                '//cpp/fanos',
-                '//cpp/libc',
-                '//cpp/osh',
-                '//cpp/pgen2',
-                '//cpp/pylib',
-                '//cpp/stdlib',
-                '//cpp/frontend_flag_spec',
-                '//cpp/frontend_match',
-                '//cpp/frontend_pyreadline',
-                '//data_lang/nil8.asdl',
-                '//display/pretty.asdl',
-                '//frontend/arg_types',
-                '//frontend/consts',
-                '//frontend/help_meta',
-                '//frontend/id_kind.asdl',
-                '//frontend/option.asdl',
-                '//frontend/signal',
-                '//frontend/syntax.asdl',
-                '//frontend/types.asdl',
-                '//core/optview',
-                '//core/runtime.asdl',
-                '//core/value.asdl',
-                '//osh/arith_parse',
-                '//ysh/grammar',
-                '//mycpp/runtime',
-            ])
+            n.build(outputs,
+                    'gen-oils-for-unix',
+                    deps,
+                    implicit=['_bin/shwrap/mycpp_main', RULES_PY],
+                    variables=variables)
+
+            if main_name == 'oils_for_unix':
+                # The main program!
+                if translator == 'mycpp-souffle':
+                    bin_path = '%s/oils-for-unix' % translator
+                else:
+                    # Keep the default mycpp build at the original location to
+                    # avoid breaking benchmarks and tests.
+                    bin_path = 'oils-for-unix'
+                symlinks = ['osh', 'ysh']
+            else:
+                symlinks = []
+                bin_path = None  # use default
+
+            ru.cc_binary(
+                '_gen/bin/%s.%s.cc' % (main_name, translator),
+                bin_path=bin_path,
+                symlinks=symlinks,
+                preprocessed=True,
+                matrix=(ninja_lib.COMPILERS_VARIANTS + ninja_lib.GC_PERF_VARIANTS +
+                        ninja_lib.OTHER_VARIANTS),
+                deps=[
+                    '//bin/text_files',
+                    '//cpp/core',
+                    '//cpp/data_lang',
+                    '//cpp/fanos',
+                    '//cpp/libc',
+                    '//cpp/osh',
+                    '//cpp/pgen2',
+                    '//cpp/pylib',
+                    '//cpp/stdlib',
+                    '//cpp/frontend_flag_spec',
+                    '//cpp/frontend_match',
+                    '//cpp/frontend_pyreadline',
+                    '//data_lang/nil8.asdl',
+                    '//display/pretty.asdl',
+                    '//frontend/arg_types',
+                    '//frontend/consts',
+                    '//frontend/help_meta',
+                    '//frontend/id_kind.asdl',
+                    '//frontend/option.asdl',
+                    '//frontend/signal',
+                    '//frontend/syntax.asdl',
+                    '//frontend/types.asdl',
+                    '//core/optview',
+                    '//core/runtime.asdl',
+                    '//core/value.asdl',
+                    '//osh/arith_parse',
+                    '//ysh/grammar',
+                    '//mycpp/runtime',
+                ])

--- a/build/native.sh
+++ b/build/native.sh
@@ -19,13 +19,22 @@ source build/common.sh  # log
 # - TODO: do this in the Soil 'cpp' task
 
 tarball-demo() {
+  translator=${1:-mycpp}
   mkdir -p _bin
 
   ./configure
 
-  time _build/oils.sh '' '' SKIP_REBUILD
+  time _build/oils.sh '' '' $translator SKIP_REBUILD
 
-  local bin=_bin/cxx-opt-sh/oils-for-unix.stripped
+  local bin
+  case $translator in
+    mycpp)
+      bin=_bin/cxx-opt-sh/oils-for-unix.stripped
+      ;;
+    *)
+      bin=_bin/cxx-opt-sh/$translator/oils-for-unix.stripped
+      ;;
+  esac
 
   ls -l $bin
 

--- a/build/ninja-rules-py.sh
+++ b/build/ninja-rules-py.sh
@@ -64,12 +64,14 @@ EOF
 
 gen-oils-for-unix() {
   local main_name=$1
-  local out_prefix=$2
-  local preamble=$3
-  shift 3  # rest are inputs
+  local translator=$2
+  local out_prefix=$3
+  local preamble=$4
+  local mycpp_opts=$5
+  shift 5  # rest are inputs
 
   # Put it in _build/tmp so it's not in the tarball
-  local tmp=_build/tmp
+  local tmp=_build/tmp/$translator
   mkdir -p $tmp
 
   local raw_cc=$tmp/${main_name}_raw.cc
@@ -82,13 +84,14 @@ gen-oils-for-unix() {
 
   _bin/shwrap/mycpp_main $mypypath $raw_cc \
     --header-out $raw_header \
+    $mycpp_opts \
     ${EXTRA_MYCPP_ARGS:-} \
     "$@"
 
   # oils_for_unix -> OILS_FOR_UNIX_MYCPP_H'
   local guard=${main_name^^}_MYCPP_H
 
-  { echo "// $main_name.mycpp.h: translated from Python by mycpp"
+  { echo "// $main_name.h: translated from Python by mycpp"
     echo
     echo "#ifndef $guard"
     echo "#define $guard"
@@ -100,7 +103,7 @@ gen-oils-for-unix() {
   } > $header_out
 
   { cat <<EOF
-// $main_name.mycpp.cc: translated from Python by mycpp
+// $main_name.cc: translated from Python by mycpp
 
 // #include "$header_out"
 

--- a/build/ninja_lib.py
+++ b/build/ninja_lib.py
@@ -73,6 +73,7 @@ GC_PERF_VARIANTS = [
 
 OTHER_VARIANTS = [
     ('cxx', 'opt+bigint'),
+    ('cxx', 'opt+souffle'),
     ('cxx', 'asan+bigint'),
 ]
 
@@ -407,6 +408,12 @@ class Rules(object):
             if c.bin_path:
                 # e.g. _bin/cxx-dbg/oils_for_unix
                 bin_ = '%s/%s' % (bin_dir, c.bin_path)
+                bin_subdir, _, bin_name = c.bin_path.rpartition('/')
+                if bin_subdir:
+                    bin_dir = '%s/%s' % (bin_dir, bin_subdir)
+                else:
+                    bin_name = c.bin_path
+
             else:
                 # e.g. _gen/mycpp/examples/classes.mycpp
                 rel_path, _ = os.path.splitext(c.main_cc)
@@ -427,7 +434,7 @@ class Rules(object):
                 self.n.build(['%s/%s' % (bin_dir, symlink)],
                              'symlink', [bin_],
                              variables=[('dir', bin_dir),
-                                        ('target', c.bin_path),
+                                        ('target', bin_name),
                                         ('new', symlink)])
                 self.n.newline()
 

--- a/build/ninja_main.py
+++ b/build/ninja_main.py
@@ -108,6 +108,7 @@ def ShellFunctions(cc_sources, f, argv0):
 #
 #   COMPILER: 'cxx' for system compiler, 'clang' or custom one [default cxx]
 #   VARIANT: 'dbg' or 'opt' [default opt]
+#   TRANSLATOR: 'mycpp' or 'mycpp-souffle' [default mycpp]
 #   SKIP_REBUILD: if non-empty, checks if the output exists before building
 
 . build/ninja-rules-cpp.sh

--- a/build/ninja_main.py
+++ b/build/ninja_main.py
@@ -333,8 +333,8 @@ def InitSteps(n):
     n.rule(
         'gen-oils-for-unix',
         command=
-        'build/ninja-rules-py.sh gen-oils-for-unix $main_name $out_prefix $preamble $in',
-        description='gen-oils-for-unix $main_name $out_prefix $preamble $in')
+        'build/ninja-rules-py.sh gen-oils-for-unix $main_name $translator $out_prefix $preamble $extra_mycpp_opts $in',
+        description='gen-oils-for-unix $main_name $translator $out_prefix $preamble $extra_mycpp_opts $in')
     n.newline()
 
 

--- a/devtools/release-native.sh
+++ b/devtools/release-native.sh
@@ -37,6 +37,8 @@ make-tar() {
   gen-oils-sh
   # Build default target to generate code
   ninja
+  # Generate code with the mycpp-souffle translator
+  ninja _gen/bin/oils_for_unix.mycpp-souffle.cc
 
   local sed_expr="s,^,${app_name}-${OILS_VERSION}/,"
   tarball-manifest | xargs -- tar --create --transform "$sed_expr" --file $tar
@@ -49,6 +51,7 @@ make-tar() {
 
 test-tar() {
   local install=${1:-}
+  local translator=${2:-mycpp}
 
   local tmp=_tmp/native-tar-test  # like oil-tar-test
   rm -r -f $tmp
@@ -57,7 +60,7 @@ test-tar() {
   tar -x < ../../_release/oils-for-unix.tar
 
   pushd oils-for-unix-$OILS_VERSION
-  build/native.sh tarball-demo
+  build/native.sh tarball-demo $translator
 
   if test -n "$install"; then
     sudo ./install

--- a/devtools/test-oils.sh
+++ b/devtools/test-oils.sh
@@ -329,7 +329,7 @@ demo() {
   pushd oils-for-unix-$OILS_VERSION
   build/native.sh tarball-demo
 
-  local osh=$PWD/_bin/cxx-opt-sh/osh 
+  local osh=$PWD/_bin/cxx-opt-sh/osh
 
   $time_py --tsv --rusage -o demo.tsv -- \
     $osh -c 'sleep 0.1; echo "hi from osh"'

--- a/mycpp/NINJA_subgraph.py
+++ b/mycpp/NINJA_subgraph.py
@@ -162,16 +162,28 @@ def TranslatorSubgraph(ru, translator, ex):
 
     # Implicit dependency: if the translator changes, regenerate source code.
     # But don't pass it on the command line.
-    translator_wrapper = '_bin/shwrap/%s_main' % translator
+    if translator == 'pea':
+        translator_wrapper = '_bin/shwrap/pea_main'
+        base_translator = 'pea'
+        translate_rule = 'translate-pea'
+    else:
+        translate_rule = 'translate-mycpp'
+        base_translator = 'mycpp'
+        translator_wrapper = '_bin/shwrap/mycpp_main'
+
+    translator_vars = [
+        ('mypypath', '$NINJA_REPO_ROOT/mycpp:$NINJA_REPO_ROOT/pyext'),
+    ]
+    if translator == 'mycpp-souffle':
+        translator_vars.append(('extra_mycpp_opts', '--minimize-stack-roots'))
 
     n.build(
         raw,
-        'translate-%s' % translator,
+        translate_rule,
         to_translate,
         implicit=[translator_wrapper],
         # examples/parse uses pyext/fastfunc.pyi
-        variables=[('mypypath',
-                    '$NINJA_REPO_ROOT/mycpp:$NINJA_REPO_ROOT/pyext')])
+        variables=translator_vars)
 
     p = 'mycpp/examples/%s_preamble.h' % ex
     # Ninja empty string!
@@ -185,7 +197,7 @@ def TranslatorSubgraph(ru, translator, ex):
             raw,
             implicit=[RULES_PY],
             variables=[('name', ex), ('preamble_path', preamble_path),
-                       ('translator', translator)])
+                       ('translator', base_translator)])
 
     n.newline()
 
@@ -194,6 +206,14 @@ def TranslatorSubgraph(ru, translator, ex):
 
     if translator == 'mycpp':
         example_matrix = COMPILERS_VARIANTS
+    elif translator == 'mycpp-souffle':
+        # mycpp-souffle only has three variants for now
+        example_matrix = [
+            ('cxx', 'opt'),  # for benchmarks
+            ('cxx', 'opt-sh'),  # for benchmarks
+            ('cxx', 'asan'), # need this for running the examples in CI
+            ('cxx', 'asan+gcalways'),
+        ]
     else:
         # pea just has one variant for now
         example_matrix = [('cxx', 'asan+gcalways')]
@@ -231,7 +251,7 @@ def NinjaGraph(ru):
 
     # mycpp and pea have the same interface
     n.rule('translate-mycpp',
-           command='_bin/shwrap/mycpp_main $mypypath $out $in',
+           command='_bin/shwrap/mycpp_main $mypypath $out $in $extra_mycpp_opts',
            description='mycpp $mypypath $out $in')
     n.newline()
 
@@ -356,7 +376,7 @@ def NinjaGraph(ru):
 
             n.newline()
 
-        for translator in ['mycpp', 'pea']:
+        for translator in ['mycpp', 'mycpp-souffle', 'pea']:
             TranslatorSubgraph(ru, translator, ex)
 
             # Don't run it for now; just compile
@@ -395,10 +415,14 @@ def NinjaGraph(ru):
                 # Only test cxx- variant
                 b_example = '_bin/cxx-%s/mycpp/examples/%s.%s' % (variant, ex,
                                                                   translator)
+                impl = 'C++'
+                if translator == 'mycpp-souffle':
+                    impl = 'C++-Souffle'
+
                 n.build([task_out, cc_log_out],
                         'example-task', [b_example],
                         variables=[('bin', b_example), ('name', ex),
-                                   ('impl', 'C++')])
+                                   ('impl', impl)])
                 n.newline()
 
     # Compare the log of all examples

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -60,6 +60,7 @@ def Options():
     p.add_option(
         '--minimize-stack-roots',
         dest='minimize_stack_roots',
+        action='store_true',
         default=False,
         help='Try to minimize the number of GC stack roots.')
 

--- a/mycpp/pass_state.py
+++ b/mycpp/pass_state.py
@@ -568,6 +568,9 @@ def ComputeMinimalStackRoots(cfgs: dict[str, ControlFlowGraph],
     that can be queried by cppgen_pass.
     """
     DumpControlFlowGraphs(cfgs, facts_dir=facts_dir)
+    # The facts files can be pretty large. Sync them first to avoid reading
+    # truncated files from the solver.
+    subprocess.run('sync {}/*.facts'.format(facts_dir), shell=True)
     subprocess.check_call([
         '_bin/datalog/dataflow',
         '-F',

--- a/yaks/NINJA_subgraph.py
+++ b/yaks/NINJA_subgraph.py
@@ -35,7 +35,7 @@ def NinjaGraph(ru):
             deps,
             implicit=['_bin/shwrap/mycpp_main', RULES_PY],
             variables=[('out_prefix', prefix), ('main_name', main_name),
-                       ('preamble', 'yaks/preamble.h')])
+                       ('translator', 'yaks'), ('preamble', 'yaks/preamble.h')])
 
     ru.cc_binary(
         '_gen/yaks/%s.mycpp.cc' % main_name,


### PR DESCRIPTION
This commit adds a new translator called `mycpp-souffle`. It translates
files using mycpp with optimizations enabled.

You can build the translation examples with souffle optimizations
enabled with the same targets you normally would, but with `mycpp`
replaced by `mycpp-souffle` in the suffix. For example, you build the
intermediate C++ and the `cxx-asan` binary for
`mycpp/examples/gc_stack_roots.py` respectively by running the following
commands:
```
ninja _gen/mycpp/examples/gc_stack_roots.mycpp-souffle.cc
ninja _bin/cxx-asan/mycpp/examples/gc_stack_roots.mycpp-souffle
```

You can also build OSH and YSH with this new variant. Their targets are
named `_bin/<variant>/mycpp-souffle/osh` and
`_bin/<variant>/mycpp-soufle/ysh` respectively. Currently, only the
`cxx-opt`, `cxx-asan`, and `cxx-asan+gcalways` variants are enabled for
the new translator. The binaries translated with vanilla mycpp are still
available at their existing paths, e.g. `_bin/cxx-dbg/osh`.

The translated C++ for the entire program with optimizations is named
`_gen/bin/oils_for_unix.mycpp-souffle.cc`.