### PR TITLE
Define procs in the current scope, not the global one

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -2390,7 +2390,7 @@ class Procs:
 
     def SetProc(self, name, proc):
         # type: (str, value.Proc) -> None
-        self.mem.var_stack[0][name] = Cell(False, False, False, proc)
+        self.mem.var_stack[-1][name] = Cell(False, False, False, proc)
 
     def SetShFunc(self, name, proc):
         # type: (str, value.Proc) -> None


### PR DESCRIPTION
Experiment for [#language-design>Metaprogramming in ysh, sort of](https://oilshell.zulipchat.com/#narrow/stream/384942-language-design/topic/Metaprogramming.20in.20ysh.2C.20sort.20of) on Zulip.