### PR TITLE
Flag changes required by `zoxide` when sourcing other shell’s startup files

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -52,7 +52,7 @@ It's very hard to tell when and if `/etc/profile`, `~/.bashrc`,
 `~/.bash_profile`, etc. are executed.
 
 OSH and YSH intentionally avoid this.  If you want those files, simply `source`
-them in your `oshrc` (see [OSH Compatibility Tips](https://github.com/oils-for-unix/oils/wiki/OSH-Compatibility-Tips) to resolve possible incompatibilities).
+them in your `oshrc`.
 
 [mess]: https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/
 
@@ -73,7 +73,7 @@ OSH](https://github.com/oilshell/oil/wiki/How-To-Test-OSH).
 - On Arch Linux and other distros,`$LANG` may not get set without
   `/etc/profile`.  Adding `source /etc/profile` to your `oshrc` may solve this
   problem.
-- See [OSH Compatibility Tips](https://github.com/oils-for-unix/oils/wiki/OSH-Compatibility-Tips) to configure programs that rely on `eval` to initialize (e.g., starship, zoxide).
+- See [OSH Compatibility Tips](https://github.com/oils-for-unix/oils/wiki/OSH-Compatibility-Tips) to configure programs that rely on `eval` to initialize (e.g. starship, zoxide).
 
 ### `sh` and Bash Docs Are Useful for OSH
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -52,7 +52,7 @@ It's very hard to tell when and if `/etc/profile`, `~/.bashrc`,
 `~/.bash_profile`, etc. are executed.
 
 OSH and YSH intentionally avoid this.  If you want those files, simply `source`
-them in your `oshrc`.
+them in your `oshrc` (see [Troubleshooting](#troubleshooting) for possible incompatibilities).
 
 [mess]: https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/
 
@@ -73,6 +73,9 @@ OSH](https://github.com/oilshell/oil/wiki/How-To-Test-OSH).
 - On Arch Linux and other distros,`$LANG` may not get set without
   `/etc/profile`.  Adding `source /etc/profile` to your `oshrc` may solve this
   problem.
+- If you use `zoxide`, add `eval "$(zoxide init posix --hook prompt)"` to the
+  end of `oshrc` and remove lines specific to other shells when sourcing their
+  startup files.
 
 ### `sh` and Bash Docs Are Useful for OSH
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -52,7 +52,7 @@ It's very hard to tell when and if `/etc/profile`, `~/.bashrc`,
 `~/.bash_profile`, etc. are executed.
 
 OSH and YSH intentionally avoid this.  If you want those files, simply `source`
-them in your `oshrc` (see [Troubleshooting](#troubleshooting) for possible incompatibilities).
+them in your `oshrc` (see [OSH Compatibility Tips](https://github.com/oils-for-unix/oils/wiki/OSH-Compatibility-Tips) to resolve possible incompatibilities).
 
 [mess]: https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/
 
@@ -73,9 +73,7 @@ OSH](https://github.com/oilshell/oil/wiki/How-To-Test-OSH).
 - On Arch Linux and other distros,`$LANG` may not get set without
   `/etc/profile`.  Adding `source /etc/profile` to your `oshrc` may solve this
   problem.
-- If you use `zoxide`, add `eval "$(zoxide init posix --hook prompt)"` to the
-  end of `oshrc` and remove lines specific to other shells when sourcing their
-  startup files.
+- See [OSH Compatibility Tips](https://github.com/oils-for-unix/oils/wiki/OSH-Compatibility-Tips) to configure programs that rely on `eval` to initialize (e.g., starship, zoxide).
 
 ### `sh` and Bash Docs Are Useful for OSH
 


### PR DESCRIPTION
https://github.com/ajeetdsouza/zoxide#installation

As other similar adjustments may be required depending on the software one has installed under previous shell, it can be helpful to collect compatible configurations in a file under `/etc/profile.d` and source it from `oshrc` and keep shell-dependent ones such as `zoxide`’s in shell-specific files like `.bashrc` and `oshrc`.