### PR TITLE
Extend args.ysh's flag proc with Float, Str support

### DIFF
--- a/doc/ref/chap-stdlib.md
+++ b/doc/ref/chap-stdlib.md
@@ -245,11 +245,11 @@ Then, create an argument parser **spec**ification:
     parser (&spec) {
       flag -v --verbose (help="Verbosely")  # default is Bool, false
 
-      flag -P --max-procs ('int', default=-1, help='''
+      flag -P --max-procs (Int, default=-1, help='''
         Run at most P processes at a time
         ''')
 
-      flag -i --invert ('bool', default=true, help='''
+      flag -i --invert (Bool, default=true, help='''
         Long multiline
         Description
         ''')
@@ -324,20 +324,22 @@ The above example declares a flag "--verbose" and a short alias "-v".
 Flags can also accept values. For example, if you wanted to accept an integer count:
 
     parser (&spec) {
-      flag -N --count ('int')
+      flag -N --count (Int)
     }
 
 Calling `parseArgs` with `ARGV = :| -n 5 |` or `ARGV = :| --count 5 |` will
 store the integer `5` under `args.count`. If the user passes in a non-integer
 value like `ARGV = :| --count abc |`, `parseArgs` will raise an error.
 
+The supported types are `Bool`, `Int`, `Float`, and `Str`.
+
 Default values for an argument can be set with the `default` named argument.
 
     parser (&spec) {
-      flag -N --count ('int', default=2)
+      flag -N --count (Int, default=2)
 
       # Boolean flags can be given default values too
-      flag -O --optimize ('bool', default=true)
+      flag -O --optimize (Bool, default=true)
     }
 
     var args = parseArgs(spec, :| -n 3 |)

--- a/stdlib/ysh/args-test.ysh
+++ b/stdlib/ysh/args-test.ysh
@@ -18,14 +18,18 @@ proc test-basic {
   parser (&spec) {
     flag -v --verbose (help="Verbosely")  # default is Bool, false
   
-    flag -P --max-procs ('int', default=-1, help='''
+    flag -P --max-procs (Int, default=-1, help='''
       Run at most P processes at a time
       ''')
   
-    flag -i --invert ('bool', default=true, help='''
+    flag -i --invert (Bool, default=true, help='''
       Long multiline
       Description
       ''')
+
+    flag -n --name (Str)
+
+    flag -s --scale (Float, default=0.0)
   
     arg src (help='Source')
     arg dest (help='Dest')
@@ -33,12 +37,23 @@ proc test-basic {
     rest files
   }
   
-  var args = parseArgs(spec, :| mysrc -P 12 mydest a b c |)
+  var args = parseArgs(spec, :| -n test --scale 1.0 mysrc -P 12 mydest a b c |)
   
   assert [false === args.verbose]
 
-  # TODO: clean up this JSON
-  var expected = {"src":"mysrc","max-procs":12,"dest":"mydest","files":["a","b","c"],"verbose":false,"invert":true}
+  assert [floatsEqual(args.scale, 1.0)]
+  call args->erase('scale') # remove Float key for subsequent equality check
+
+  var expected = {
+    "name": "test",
+    "src": "mysrc",
+    "max-procs": 12,
+    "dest": "mydest",
+    "files": :| a b c |,
+    "verbose": false,
+    "invert":true,
+  }
+
   assert [expected === args]
 }
 
@@ -46,7 +61,7 @@ proc test-2 {
   ### Bool flag, positional args, more positional
 
   parser (&spec) {
-    flag -v --verbose ('bool')
+    flag -v --verbose (Bool)
     arg src
     arg dst
 
@@ -68,22 +83,26 @@ proc test-2 {
 proc test-default-values {
 
   parser (&spec) {
-    flag -S --sanitize ('bool', default=false)
-    flag -v --verbose ('bool', default=false)
-    flag -P --max-procs ('int')  # Will set to null (the default default)
+    flag -S --sanitize (Bool, default=false)
+    flag -v --verbose (Bool, default=false)
+    flag -P --max-procs (Int)  # Will set to null (the default default)
   }
 
   var args = parseArgs(spec, [])
 
   #pp test_ (args)
-  var expected = {"sanitize":false,"verbose":false,"max-procs":null}
+  var expected = {
+    "sanitize": false,
+    "verbose": false,
+    "max-procs": null,
+  }
   assert [expected === args]
 }
 
 proc test-multiple-argv-arrays {
   parser (&spec) {
-    flag -v --verbose ('bool', default=false)
-    flag -c --count ('int', default=120)
+    flag -v --verbose (Bool, default=false)
+    flag -c --count (Int, default=120)
     arg file
   }
 
@@ -156,7 +175,7 @@ proc test-more-errors {
 
   parser (&spec) {
     flag -v --verbose
-    flag -n --num ('int', required=true)
+    flag -n --num (Int, required=true)
 
     arg action
     arg other (required=false)
@@ -182,53 +201,53 @@ proc test-more-errors {
 }
 
 proc test-print-spec {
-
   parser (&spec) {
-    flag -v --verbose ('bool')
+    flag -v --verbose (Bool)
     arg src
     arg dst
 
     rest more  # allow more args
   }
 
-  yb-capture (&r) {
-    json write (spec)
-  }
-
-  var expected = '''
-  {
-    "flags": [
+  var expected = {
+    flags: [
       {
-        "short": "-v",
-        "long": "--verbose",
-        "name": "verbose",
-        "type": "bool",
-        "default": false,
-        "help": null
+        short: "-v",
+        long: "--verbose",
+        name: "verbose",
+        type: Bool,
+        default: false,
+        help: null
       }
     ],
-    "args": [
+    args: [
       {
-        "name": "src",
-        "help": null
+        name: "src",
+        help: null
       },
       {
-        "name": "dst",
-        "help": null
+        name: "dst",
+        help: null
       }
     ],
-    "rest": "more"
+    rest: "more"
   }
-  '''
 
-  assert [expected === r.stdout]
+  # Type objects cannot be tested for equality, so check them for identity then
+  # erase the keys so the remainder of the Dict can be tested for equality.
+  for i, flag in (expected.flags) {
+    assert [flag.type is spec.flags[i].type]
+    call expected.flags[i]->erase('type')
+    call spec.flags[i]->erase('type')
+  }
+  assert [expected === spec]
 }
 
 proc test-vs-python3-argparse {
   var spec = {
     flags: [
       {short: '-v', long: '--verbose', name: 'verbose', type: null, default: '', help: 'Enable verbose logging'},
-      {short: '-c', long: '--count', name: 'count', type: 'int', default: 80, help: 'Maximum line length'},
+      {short: '-c', long: '--count', name: 'count', type: Int, default: 80, help: 'Maximum line length'},
     ],
     args: [
       {name: 'file', type: 'str', help: 'File to check line lengths of'}

--- a/stdlib/ysh/args.ysh
+++ b/stdlib/ysh/args.ysh
@@ -10,11 +10,11 @@ const __provide__ = :| parser flag arg rest parseArgs |
 # parser (&spec) {
 #   flag -v --verbose (help="Verbosely")  # default is Bool, false
 #
-#   flag -P --max-procs ('int', default=-1, doc='''
+#   flag -P --max-procs (Int, default=-1, doc='''
 #     Run at most P processes at a time
 #     ''')
 #
-#   flag -i --invert ('bool', default=true, doc='''
+#   flag -i --invert (Bool, default=true, doc='''
 #     Long multiline
 #     Description
 #     ''')
@@ -33,7 +33,6 @@ const __provide__ = :| parser flag arg rest parseArgs |
 # TODO: See list
 # - It would be nice to keep `flag` and `arg` private, injecting them into the
 #   proc namespace only within `Args`
-# - We need "type object" to replace the strings 'int', 'bool', etc.
 # - flag builtin:
 #   - handle only long flag or only short flag
 #   - flag aliases
@@ -45,7 +44,7 @@ proc parser (; place ; ; block_def) {
   ##
   ##   # NOTE: &spec will create a variable named spec
   ##   parser (&spec) {
-  ##     flag -v --verbose ('bool')
+  ##     flag -v --verbose (Bool)
   ##   }
   ##
   ##   var args = parseArgs(spec, ARGV)
@@ -80,26 +79,46 @@ proc parser (; place ; ; block_def) {
   call place->setValue(p)
 }
 
-proc flag (short, long ; type='bool' ; default=null, help=null) {
+const kValidTypes = [Bool, Float, Int, Str]
+const kValidTypeNames = []
+for vt in (kValidTypes) {
+  call kValidTypeNames->append(vt.name)
+}
+
+func isValidType (type) {
+  try {
+    for valid in (kValidTypes) {
+      if (type is valid) {
+        return (true)
+      }
+    }
+  }
+  return (false)
+}
+
+proc flag (short, long ; type=Bool ; default=null, help=null) {
   ## Declare a flag within an `arg-parse`.
   ##
   ## Examples:
   ##
   ##   arg-parse (&spec) {
   ##     flag -v --verbose
-  ##     flag -n --count ('int', default=1)
-  ##     flag -f --file ('str', help="File to process")
+  ##     flag -n --count (Int, default=1)
+  ##     flag -p --percent (Float, default=0.0)
+  ##     flag -f --file (Str, help="File to process")
   ##   }
 
-  # bool has a default of false, not null
-  if (type === 'bool' and default === null) {
+  if (type !== null and not isValidType(type)) {
+    var type_names = ([null] ++ kValidTypeNames) => join(', ')
+    error "Expected flag type to be one of: $type_names" (code=2)
+  }
+
+  # Bool has a default of false, not null
+  if (type is Bool and default === null) {
     setvar default = false
   }
 
-  # TODO: validate `type`
-
-  # TODO: Should use "trimPrefix"
-  var name = long[2:]
+  var name = long => trimStart('--')
 
   ctx emit flags ({short, long, name, type, default, help})
 }
@@ -153,19 +172,35 @@ func parseArgs(spec, argv) {
       for flag in (spec.flags) {
         if ( (flag.short and flag.short === arg) or
              (flag.long and flag.long === arg) ) {
-          case (flag.type) {
-            ('bool') | (null) { setvar value = true }
-            int {
-              setvar i += 1
-              if (i >= len(argv)) {
-                error "Expected integer after '$arg'" (code=2)
-              }
-
-              try { setvar value = int(argv[i]) }
-              if (_status !== 0) {
-                error "Expected integer after '$arg', got '$[argv[i]]'" (code=2)
-              }
+          if (flag.type === null or flag.type is Bool) {
+            setvar value = true
+          } elif (flag.type is Int) {
+            setvar i += 1
+            if (i >= len(argv)) {
+              error "Expected Int after '$arg'" (code=2)
             }
+
+            try { setvar value = int(argv[i]) }
+            if (_status !== 0) {
+              error "Expected Int after '$arg', got '$[argv[i]]'" (code=2)
+            }
+          } elif (flag.type is Float) {
+            setvar i += 1
+            if (i >= len(argv)) {
+              error "Expected Float after '$arg'" (code=2)
+            }
+
+            try { setvar value = float(argv[i]) }
+            if (_status !== 0) {
+              error "Expected Float after '$arg', got '$[argv[i]]'" (code=2)
+            }
+          } elif (flag.type is Str) {
+            setvar i += 1
+            if (i >= len(argv)) {
+              error "Expected Str after '$arg'" (code=2)
+            }
+
+            setvar value = argv[i]
           }
 
           setvar args[flag.name] = value


### PR DESCRIPTION
Additionally, now that basic support for type objects has been added (ref: 9db992cc), refactor to use type objects for flag types. This provides a cleaner, more strict interface when describing flags (e.g., `flag -c --count (Int)`).