### PR TITLE
[ysh] Lex '&&', '||' for better errors in expr mode

### DIFF
--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -179,29 +179,33 @@ Examples:
 Incorrect:
 
     # Expression mode
-    if (a || b) {
-      echo yes
+    if (!a || b && c) {
+      echo no
     }
 
     # Command mode
-    if test --dir a or test --dir b { ... }
+    if not test --dir a or test --dir b and test --dir c {
+      echo no
+    }
 
 Correct:
 
     # Expression mode
-    if (a or b) {
+    if (not a or b and c) {
       echo yes
     }
 
     # Command mode
-    if test --dir a || test --dir b { ... }
+    if ! test --dir a || test --dir b && test --dir c {
+      echo yes
+    }
 
 In general, code within parentheses `()` is parsed as Python-like expressions
 -- referred to as [expression mode](command-vs-expression-mode.html). The
 standard boolean operators are written as `a and b`, `a or b` and `not a`.
 
 This differs from [command mode](command-vs-expression-mode.html) which uses
-`||` for "OR", `&&` for "AND" and `!` for "NOT".
+shell-like `||` for "OR", `&&` for "AND" and `!` for "NOT".
 
 ## Runtime Errors - Traditional Shell
 

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -174,6 +174,35 @@ Examples:
       echo yes
     }
 
+### OILS-ERR-15
+
+Incorrect:
+
+    # Expression mode
+    if (a || b) {
+      echo yes
+    }
+
+    # Command mode
+    if test --dir a or test --dir b { ... }
+
+Correct:
+
+    # Expression mode
+    if (a or b) {
+      echo yes
+    }
+
+    # Command mode
+    if test --dir a || test --dir b { ... }
+
+In general, code within parentheses `()` is parsed as Python-like expressions
+-- referred to as [expression mode](command-vs-expression-mode.html). The
+standard boolean operators are written as `a and b`, `a or b` and `not a`.
+
+This differs from [command mode](command-vs-expression-mode.html) which uses
+`||` for "OR", `&&` for "AND" and `!` for "NOT".
+
 ## Runtime Errors - Traditional Shell
 
 These errors may occur in shells like [bash]($xref) and [zsh]($xref).

--- a/frontend/id_kind_def.py
+++ b/frontend/id_kind_def.py
@@ -232,7 +232,7 @@ def AddKinds(spec):
     #   $'\z'  Such bad codes are accepted when parse_backslash is on
     #          (default in OSH), so we have to lex them.
     #  (x == y) should used === or ~==
-    spec.AddKind('Unknown', ['Tok', 'Backslash', 'DEqual'])
+    spec.AddKind('Unknown', ['Tok', 'Backslash', 'DEqual', 'DAmp', 'DPipe'])
 
     spec.AddKind('Eol', ['Tok'])  # no more tokens on line (\0)
 

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -1056,6 +1056,9 @@ LEXER_DEF[lex_mode_e.Expr] = \
 
     C('==', Id.Unknown_DEqual),  # user must choose === or ~==
 
+    C('&&', Id.Unknown_DAmp),
+    C('||', Id.Unknown_DPipe),
+
     # Bitwise operators
     C('&', Id.Arith_Amp),
     C('|', Id.Arith_Pipe),

--- a/test/ysh-parse-errors.sh
+++ b/test/ysh-parse-errors.sh
@@ -1689,6 +1689,12 @@ test-eggex() {
   _osh-parse-error '= /dot{*} /'
 }
 
+test-unknown-boolops() {
+  _osh-parse-error '= a && b'
+  _osh-parse-error '= a || b'
+  _osh-parse-error '= !a'
+}
+
 #
 # Entry Points
 #

--- a/ysh/expr_parse.py
+++ b/ysh/expr_parse.py
@@ -79,6 +79,11 @@ def _Classify(gr, tok):
 
     if id_ == Id.Unknown_DEqual:
         p_die('Use === to be exact, or ~== to convert types', tok)
+    if id_ == Id.Unknown_DAmp:
+        p_die("Use 'and' in expression mode", tok)
+    if id_ == Id.Unknown_DPipe:
+        p_die("Use 'or' in expression mode", tok)
+    # Not possible to check '!' as it conflicts with Id.Expr_Bang
 
     if id_ == Id.Unknown_Tok:
         type_str = ''

--- a/ysh/expr_parse.py
+++ b/ysh/expr_parse.py
@@ -80,9 +80,9 @@ def _Classify(gr, tok):
     if id_ == Id.Unknown_DEqual:
         p_die('Use === to be exact, or ~== to convert types', tok)
     if id_ == Id.Unknown_DAmp:
-        p_die("Use 'and' in expression mode", tok)
+        p_die("Use 'and' in expression mode (OILS-ERR-15)", tok)
     if id_ == Id.Unknown_DPipe:
-        p_die("Use 'or' in expression mode", tok)
+        p_die("Use 'or' in expression mode (OILS-ERR-15)", tok)
     # Not possible to check '!' as it conflicts with Id.Expr_Bang
 
     if id_ == Id.Unknown_Tok:


### PR DESCRIPTION
Lex '&&', '||' in expression mode for better error messages:

```
  = a && b
      ^~
[ -c flag ]:1: Use 'and' in expression mode

  = a || b
      ^~
[ -c flag ]:1: Use 'or' in expression mode
```

Eggex has `Expr_Bang` which means we cannot check this case the same way:

```
  = !a
    ^
[ -c flag ]:1: Syntax error in expression (near Id.Expr_Bang)
```

(I don't think it's possible to cleanly check this specific error unless we moved away from pgen2.)