### PR TITLE
[stdlib/args] Support flags that remember all values passed, with List[T] syntax

### DIFF
--- a/doc/ref/chap-stdlib.md
+++ b/doc/ref/chap-stdlib.md
@@ -327,11 +327,22 @@ Flags can also accept values. For example, if you wanted to accept an integer co
       flag -N --count (Int)
     }
 
-Calling `parseArgs` with `ARGV = :| -n 5 |` or `ARGV = :| --count 5 |` will
+Calling `parseArgs` with `ARGV = :| -N 5 |` or `ARGV = :| --count 5 |` will
 store the integer `5` under `args.count`. If the user passes in a non-integer
 value like `ARGV = :| --count abc |`, `parseArgs` will raise an error.
 
-The supported types are `Bool`, `Int`, `Float`, and `Str`.
+The supported flag types are `Bool`, `Int`, `List[Int]`, `Float`, `List[Float]`,
+`Str`, and `List[Str]`.
+
+Flags with a `List` type may be provided multiple times. For example, if you
+wanted to accept a list of strings:
+
+    parser (&spec) {
+        flag -f --file (List[Str])
+    }
+
+Calling `parseArgs` with `ARGV = :| -f a --file b -f c |` will store the value
+`['a', 'b', 'c']` under `args.file`.
 
 Default values for an argument can be set with the `default` named argument.
 

--- a/stdlib/ysh/args-test.ysh
+++ b/stdlib/ysh/args-test.ysh
@@ -319,6 +319,34 @@ proc test-vs-python3-argparse {
   #assert [expected === r.stdout]
 }
 
+proc test-multi-value-flags {
+  parser (&spec) {
+    flag -f --float (List[Float])
+    flag -i --int (List[Int])
+    flag -s --str (List[Str])
+  }
+
+  var args = parseArgs(spec, :| -f 1.0 -s one -i 0 --str two --int 1 -s three |)
+
+  assert [type(args.float) === 'List']
+  assert [len(args.float) === 1]
+  assert [floatsEqual(args.float[0], 1.0)]
+
+  call args->erase('float') # remove List[Float] value for subsequent equality check
+
+  var expected = {
+    "int": [0, 1],
+    "str": :| one two three |,
+  }
+
+  assert [expected === args]
+
+  try { call parseArgs(spec, :| -f not_a_float |) }
+  assert [2 === _error.code]
+  try { call parseArgs(spec, :| -i not_an_int |) }
+  assert [2 === _error.code]
+}
+
 if is-main {
   byo-maybe-run
 }

--- a/stdlib/ysh/args.ysh
+++ b/stdlib/ysh/args.ysh
@@ -191,7 +191,7 @@ func parseArgs(spec, argv) {
               error "Expected Int after '$arg'" (code=2)
             }
 
-            setvar value = args[flag.name] if (flag.name in args) else []
+            setvar value = get(args, flag.name, [])
             try { call value->append(int(argv[i])) }
             if (_status !== 0) {
               error "Expected Int after '$arg', got '$[argv[i]]'" (code=2)
@@ -212,7 +212,7 @@ func parseArgs(spec, argv) {
               error "Expected Float after '$arg'" (code=2)
             }
 
-            setvar value = args[flag.name] if (flag.name in args) else []
+            setvar value = get(args, flag.name, [])
             try { call value->append(float(argv[i])) }
             if (_status !== 0) {
               error "Expected Float after '$arg', got '$[argv[i]]'" (code=2)
@@ -230,7 +230,7 @@ func parseArgs(spec, argv) {
               error "Expected Str after '$arg'" (code=2)
             }
 
-            setvar value = args[flag.name] if (flag.name in args) else []
+            setvar value = get(args, flag.name, [])
             call value->append(argv[i])
           }
 

--- a/stdlib/ysh/args.ysh
+++ b/stdlib/ysh/args.ysh
@@ -34,7 +34,7 @@ const __provide__ = :| parser parseArgs |
 # - flag builtin:
 #   - handle only long flag or only short flag
 #   - flag aliases
-#   - support repeated or character-delimited multi-value flags
+#   - assert that default value has the declared type
 
 proc parser (; place ; ; block_def) {
   ## Create an args spec which can be passed to parseArgs.
@@ -80,18 +80,17 @@ proc parser (; place ; ; block_def) {
   call place->setValue(p)
 }
 
-const kValidTypes = [Bool, Float, Int, Str]
+const kValidTypes = [Bool, Float, List[Float], Int, List[Int], Str, List[Str]]
 const kValidTypeNames = []
 for vt in (kValidTypes) {
-  call kValidTypeNames->append(vt.name)
+  var name = vt.name if ('name' in propView(vt)) else vt.unique_id
+  call kValidTypeNames->append(name)
 }
 
 func isValidType (type) {
-  try {
-    for valid in (kValidTypes) {
-      if (type is valid) {
-        return (true)
-      }
+  for valid in (kValidTypes) {
+    if (type is valid) {
+      return (true)
     }
   }
   return (false)
@@ -107,6 +106,7 @@ proc flag (short, long ; type=Bool ; default=null, help=null) {
   ##     flag -n --count (Int, default=1)
   ##     flag -p --percent (Float, default=0.0)
   ##     flag -f --file (Str, help="File to process")
+  ##     flag -e --exclude (List[Str], help="File to exclude")
   ##   }
 
   if (type !== null and not isValidType(type)) {
@@ -185,6 +185,17 @@ func parseArgs(spec, argv) {
             if (_status !== 0) {
               error "Expected Int after '$arg', got '$[argv[i]]'" (code=2)
             }
+          } elif (flag.type is List[Int]) {
+            setvar i += 1
+            if (i >= len(argv)) {
+              error "Expected Int after '$arg'" (code=2)
+            }
+
+            setvar value = args[flag.name] if (flag.name in args) else []
+            try { call value->append(int(argv[i])) }
+            if (_status !== 0) {
+              error "Expected Int after '$arg', got '$[argv[i]]'" (code=2)
+            }
           } elif (flag.type is Float) {
             setvar i += 1
             if (i >= len(argv)) {
@@ -195,6 +206,17 @@ func parseArgs(spec, argv) {
             if (_status !== 0) {
               error "Expected Float after '$arg', got '$[argv[i]]'" (code=2)
             }
+          } elif (flag.type is List[Float]) {
+            setvar i += 1
+            if (i >= len(argv)) {
+              error "Expected Float after '$arg'" (code=2)
+            }
+
+            setvar value = args[flag.name] if (flag.name in args) else []
+            try { call value->append(float(argv[i])) }
+            if (_status !== 0) {
+              error "Expected Float after '$arg', got '$[argv[i]]'" (code=2)
+            }
           } elif (flag.type is Str) {
             setvar i += 1
             if (i >= len(argv)) {
@@ -202,6 +224,14 @@ func parseArgs(spec, argv) {
             }
 
             setvar value = argv[i]
+          } elif (flag.type is List[Str]) {
+            setvar i += 1
+            if (i >= len(argv)) {
+              error "Expected Str after '$arg'" (code=2)
+            }
+
+            setvar value = args[flag.name] if (flag.name in args) else []
+            call value->append(argv[i])
           }
 
           setvar args[flag.name] = value


### PR DESCRIPTION
Following the implementation of parameterized type objects in 4cbfa15f6, it is now possible to extend the set of supported flag types with List variants to provide multi-value flags.