### PR TITLE
implement pretty printing for value.Obj

### DIFF
--- a/spec/ysh-object.test.sh
+++ b/spec/ysh-object.test.sh
@@ -255,7 +255,9 @@ var methods = Object(superClassMethods, {foo: 42, bar: [1,2]})
 var instance = Object(methods, {foo: 1, bar: 2, x: 3})
 
 pp test_ (instance)
+pp value (instance)
 
 ## STDOUT:
 (Obj)   ("foo":1,"bar":2,"x":3) --> ("foo":42,"bar":[1,2]) --> ("foo":"zz")
+(Obj)   (foo: 1, bar: 2, x: 3) --> (foo: 42, bar: [1, 2]) --> (foo: 'zz')
 ## END

--- a/spec/ysh-printing.test.sh
+++ b/spec/ysh-printing.test.sh
@@ -326,14 +326,17 @@ pp test_ (two)
 (List)   [{"k":42,"cycle":{...}},{"k":42,"cycle":{...}}]
 ## END
 
-#### pp test_: Obj cycle
+#### pp: Obj cycle
 
 var methods = Object(null, {__foo__: null})
 var obj = Object(methods, {z: 99})
 pp test_ (obj)
+pp value (obj)
+echo
 
 setvar obj.cycle = obj
 pp test_ (obj)
+pp value (obj)
 
 echo
 
@@ -342,7 +345,10 @@ pp test_ (two)
 
 ## STDOUT:
 (Obj)   ("z":99) --> ("__foo__":null)
+(Obj)   (z: 99) --> (__foo__: null)
+
 (Obj)   ("z":99,"cycle":(...)) --> ("__foo__":null)
+(Obj)   (z: 99, cycle: (...)) --> (__foo__: null)
 
 (List)   [("z":99,"cycle":(...)) --> ("__foo__":null),("z":99,"cycle":(...)) --> ("__foo__":null)]
 ## END


### PR DESCRIPTION
This commit adds a quick implementation of `pp value` (and by extension `=`) for objects. It generates pleasing output, but might not be optimal. I figure we can check this in and tweak it as we find cases that yield wonky outputs. What do folks think?