### PR TITLE
Fix links from OILS-ERR-10 going to OSH cmd lang page not YSH cmd lang

### DIFF
--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -76,14 +76,14 @@ test/ysh-parse-errors.sh test-func-var-checker
 [ -c flag ]:3: setvar couldn't find matching 'var x' (OILS-ERR-10)
 ```
 
-- Did you forget to declare the name with the [var](ref/chap-cmd-lang.html#var)
+- Did you forget to declare the name with the [var](ref/chap-ysh-cmd.html#var)
   keyword?
-- Did you mean to use the [setglobal](ref/chap-cmd-lang.html#setglobal)
+- Did you mean to use the [setglobal](ref/chap-ysh-cmd.html#setglobal)
   keyword?
 
 Related help topics:
 
-- [setvar](ref/chap-cmd-lang.html#setvar)
+- [setvar](ref/chap-ysh-cmd.html#setvar)
 
 ### OILS-ERR-11
 


### PR DESCRIPTION
Previously the OILS-ERR-10 entry would link to the wrong page.