### PR TITLE
[build] Make NINJA-config.sh work in symlinked working directories

### DIFF
--- a/NINJA-config.sh
+++ b/NINJA-config.sh
@@ -9,6 +9,12 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
+# Resolve symlinks in the current working directory.  This is needed to make
+# `grep $REPO_ROOT...` in `repo-filter (build/dynamic-deps.sh)` work.  Later,
+# `repo-filter` and related parts may be rewritten using AWK to handle it
+# better.
+cd -P .
+
 source build/dev-shell.sh  # python2 in $PATH
 source build/dynamic-deps.sh  # py-tool, etc
 

--- a/NINJA-config.sh
+++ b/NINJA-config.sh
@@ -9,12 +9,6 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-# Resolve symlinks in the current working directory.  This is needed to make
-# `grep $REPO_ROOT...` in `repo-filter (build/dynamic-deps.sh)` work.  Later,
-# `repo-filter` and related parts may be rewritten using AWK to handle it
-# better.
-cd -P .
-
 source build/dev-shell.sh  # python2 in $PATH
 source build/dynamic-deps.sh  # py-tool, etc
 

--- a/build/dynamic-deps.sh
+++ b/build/dynamic-deps.sh
@@ -9,7 +9,11 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
+# Note on the cd option, "-P": Resolve symlinks in the current working
+# directory.  This is needed to make `grep $REPO_ROOT...` in `repo-filter
+# (build/dynamic-deps.sh)` work.  Later, `repo-filter` and related parts may be
+# rewritten using AWK to handle it better.
+REPO_ROOT=$(cd -P "$(dirname $0)/.."; pwd)
 
 readonly PY_PATH='.:vendor/'
 


### PR DESCRIPTION
Fixes an issue discussed in [oil-dev > 2024-11-22 Meeting Zulip](https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/2024-11-22.20Meeting/near/484014206). The file `all-pairs.txt` generated by `build/dynamic_deps.py py-manifest` seems to contain the resolved path, while `REPO_ROOT` contained an unresolved path.