### PR TITLE
[build/deps] Add the "libasan" package to the Fedora dependencies

### DIFF
--- a/build/deps.sh
+++ b/build/deps.sh
@@ -220,6 +220,8 @@ readonly -a WEDGE_DEPS_FEDORA=(
   # still have a job control error compiling bash
   # https://packages.fedoraproject.org/pkgs/glibc/glibc-devel/
   # glibc-devel
+
+  libasan
 )
 
 readonly -a WEDGE_DEPS_ARCH=(


### PR DESCRIPTION
Without this package, `ninja` fails.