### PR TITLE
[refactor] Add "core/bash_impl" for array operations

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -1,0 +1,34 @@
+"""bash_impl.py - implements operations on Bash data structures"""
+
+from _devbuild.gen.value_asdl import value
+
+
+#------------------------------------------------------------------------------
+# All BashArray operations depending on the internal
+# representation of SparseArray come here.
+
+def BashArray_Length(array_val):
+    # type: (value.BashArray) -> int
+
+    # There can be empty placeholder values in the array.
+    length = 0
+    for s in array_val.strs:
+        if s is not None:
+            length += 1
+    return length
+
+#------------------------------------------------------------------------------
+# All BashAssoc operations depending on the internal
+# representation of SparseArray come here.
+
+def BashAssoc_Length(assoc_val):
+    # type: (value.BashAssoc) -> int
+    return len(assoc_val.d)
+
+#------------------------------------------------------------------------------
+# All SparseArray operations depending on the internal
+# representation of SparseArray come here.
+
+def SparseArray_Length(sparse_val):
+    # type: (value.SparseArray) -> int
+    return len(sparse_val.d)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -48,6 +48,7 @@ from _devbuild.gen.value_asdl import (
     sh_lvalue,
     sh_lvalue_t,
 )
+from core import bash_impl
 from core import error
 from core import pyos
 from core import pyutil
@@ -789,19 +790,15 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
             elif case(value_e.BashArray):
                 val = cast(value.BashArray, UP_val)
-                # There can be empty placeholder values in the array.
-                length = 0
-                for s in val.strs:
-                    if s is not None:
-                        length += 1
-
-            elif case(value_e.SparseArray):
-                val = cast(value.SparseArray, UP_val)
-                length = len(val.d)
+                length = bash_impl.BashArray_Length(val)
 
             elif case(value_e.BashAssoc):
                 val = cast(value.BashAssoc, UP_val)
-                length = len(val.d)
+                length = bash_impl.BashAssoc_Length(val)
+
+            elif case(value_e.SparseArray):
+                val = cast(value.SparseArray, UP_val)
+                length = bash_impl.SparseArray_Length(val)
 
             else:
                 raise error.TypeErr(

--- a/pea/oils-typecheck.txt
+++ b/pea/oils-typecheck.txt
@@ -44,6 +44,7 @@ builtin/read_osh.py
 builtin/readline_osh.py
 builtin/trap_osh.py
 core/alloc.py
+core/bash_impl.py
 core/comp_ui.py
 core/completion.py
 core/dev.py


### PR DESCRIPTION
https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/2024-11-22.20Meeting/near/484115604

This creates a file `core/bash_impl.py` and includes the `Length` operation for BashArray/BashAssoc/SparseArray as an example.