### PR TITLE
[core/state] Fix BashArray crash on `a=(); a[-1]=1`

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -1974,8 +1974,10 @@ class Mem(object):
                         index = lval.index
                         if index < 0:  # a[-1]++ computes this twice; could we avoid it?
                             index += n
+                            if index < 0:
+                                e_die("Index %d is out of range" % lval.index, left_loc)
 
-                        if 0 <= index and index < n:
+                        if index < n:
                             strs[index] = rval.s
                         else:
                             # Fill it in with None.  It could look like this:

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -801,3 +801,26 @@ two=1
 ## N-I mksh status: 1
 ## N-I mksh STDOUT:
 ## END
+
+#### Assigning with out-of-range negative index
+a=()
+a[-1]=1
+
+## status: 1
+## STDOUT:
+## END
+## STDERR:
+  a[-1]=1
+  ^~
+[ stdin ]:2: fatal: Index -1 is out of range
+## END
+
+## OK bash STDERR:
+bash: line 2: a[-1]: bad array subscript
+## END
+
+# Note: mksh interprets -1 as 0xFFFFFFFF
+## N-I mksh status: 0
+## N-I mksh STDERR:
+## END
+


### PR DESCRIPTION
The current master crashes with the following:

```console
$ bin/osh -c 'arr=(); arr[-1]=1'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 201, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 170, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 140, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1211, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2072, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1871, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1709, in _Dispatch
    status = self._ExecuteList(node.children)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1948, in _ExecuteList
    status = self._Execute(child)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1871, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1608, in _Dispatch
    status = self._DoShAssignment(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 974, in _DoShAssignment
    self.mem.SetValue(lval, val, which_scopes, flags=flags)
  File "/home/murase/.mwg/git/oilshell/oil/core/state.py", line 1987, in SetValue
    strs[lval.index] = rval.s
IndexError: list assignment index out of range
```
