### PR TITLE
[osh/sh_expr_eval] Support `[[ -v a[-1] ]]` for BashArray

### DIFF
--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -1030,9 +1030,8 @@ class BoolEvaluator(ArithEvaluator):
                 if index < 0:
                     index += n
                     if index < 0:
-                        if self.exec_opts.strict_word_eval():
-                            e_die('-v got invalid negative index %s' % index_str,
-                                  blame_loc)
+                        e_die('-v got invalid negative index %s' % index_str,
+                              blame_loc)
                         return False
 
                 if index < n:

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -1026,13 +1026,16 @@ class BoolEvaluator(ArithEvaluator):
                             index_str, blame_loc)
                     return False
 
+                n = len(val.strs)
                 if index < 0:
-                    if self.exec_opts.strict_word_eval():
-                        e_die('-v got invalid negative index %s' % index_str,
-                              blame_loc)
-                    return False
+                    index += n
+                    if index < 0:
+                        if self.exec_opts.strict_word_eval():
+                            e_die('-v got invalid negative index %s' % index_str,
+                                  blame_loc)
+                        return False
 
-                if index < len(val.strs):
+                if index < n:
                     return val.strs[index] is not None
 
                 # out of range

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -853,6 +853,9 @@ e=()
 
 ## status: 1
 ## STDERR:
+  [[ -v e[-1] ]] && echo 'e has -1'
+        ^
+[ stdin ]:2: fatal: -v got invalid negative index -1
 ## END
 
 ## OK bash STDERR:

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -824,3 +824,41 @@ bash: line 2: a[-1]: bad array subscript
 ## N-I mksh STDERR:
 ## END
 
+
+#### Negative index in [[ -v a[index] ]]
+a[0]=x
+a[5]=y
+a[10]=z
+[[ -v a[-1] ]] && echo 'a has -1'
+[[ -v a[-2] ]] && echo 'a has -2'
+[[ -v a[-5] ]] && echo 'a has -5'
+[[ -v a[-6] ]] && echo 'a has -6'
+[[ -v a[-10] ]] && echo 'a has -10'
+[[ -v a[-11] ]] && echo 'a has -11'
+
+## STDOUT:
+a has -1
+a has -6
+a has -11
+## END
+
+## N-I mksh status: 1
+## N-I mksh STDOUT:
+## END
+
+
+#### Negative out-of-range index in [[ -v a[index] ]]
+e=()
+[[ -v e[-1] ]] && echo 'e has -1'
+
+## status: 1
+## STDERR:
+## END
+
+## OK bash STDERR:
+bash: line 2: e: bad array subscript
+## END
+
+## N-I mksh STDERR:
+mksh: <stdin>[2]: syntax error: 'e[-1]' unexpected operator/operand
+## END


### PR DESCRIPTION
In the current master branch, `[[ -v a[-1] ]]` always returns exit status 1 even when there are elements and `"${a[-1]}"` is valid.