### PR TITLE
[builtin/assign_osh] Support `declare -p` for SparseArray

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -11,6 +11,7 @@ from _devbuild.gen.runtime_asdl import (
 from _devbuild.gen.value_asdl import (value, value_e, value_t, LeftName)
 from _devbuild.gen.syntax_asdl import loc, loc_t, word_t
 
+from core import bash_impl
 from core import error
 from core.error import e_usage
 from core import state
@@ -131,7 +132,7 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
         if flag_x == '+' and cell.exported:
             continue
 
-        if flag_a and val.tag() != value_e.BashArray:
+        if flag_a and val.tag() not in [value_e.BashArray, value_e.SparseArray]:
             continue
         if flag_A and val.tag() != value_e.BashAssoc:
             continue
@@ -145,7 +146,7 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
                 flags.append('r')
             if cell.exported:
                 flags.append('x')
-            if val.tag() == value_e.BashArray:
+            if val.tag() in [value_e.BashArray, value_e.SparseArray]:
                 flags.append('a')
             elif val.tag() == value_e.BashAssoc:
                 flags.append('A')
@@ -206,6 +207,10 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
                 body.extend(["[", key_quoted, "]=", value_quoted])
             if len(body) > 0:
                 decl.extend(["=(", ''.join(body), ")"])
+
+        elif val.tag() == value_e.SparseArray:
+            sparse_val = cast(value.SparseArray, val)
+            decl.extend(["=", bash_impl.SparseArray_ToStrForShellPrint(sparse_val)])
 
         else:
             pass  # note: other types silently ignored

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -2,6 +2,12 @@
 
 from _devbuild.gen.value_asdl import value
 
+from data_lang import j8_lite
+from mycpp import mops
+from mycpp import mylib
+
+from typing import List
+
 
 #------------------------------------------------------------------------------
 # All BashArray operations depending on the internal
@@ -32,3 +38,18 @@ def BashAssoc_Length(assoc_val):
 def SparseArray_Length(sparse_val):
     # type: (value.SparseArray) -> int
     return len(sparse_val.d)
+
+def SparseArray_ToStrForShellPrint(sparse_val):
+    # type: (value.SparseArray) -> str
+
+    body = [] # type: List[str]
+    keys = sparse_val.d.keys()
+    mylib.BigIntSort(keys)
+    for index in keys:
+        if len(body) > 0:
+            body.append(" ")
+        body.extend([
+            "[", mops.ToStr(index), "]=",
+            j8_lite.MaybeShellEncode(sparse_val.d[index])
+        ])
+    return "(%s)" % ''.join(body)

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -333,7 +333,8 @@ keys: 0 1 2 3 4 10 12
 ## N-I bash/zsh/mksh/ash STDOUT:
 ## END
 
-#### test that length works after conversion to SparseArray
+
+#### SparseArray: test length
 case $SH in bash|zsh|mksh|ash) exit ;; esac
 
 declare -a a=(x y z)
@@ -358,4 +359,56 @@ len=5
 ## END
 
 
+#### SparseArray: test "declare -p sp"
+case $SH in zsh|ash) exit ;; esac
 
+a0=()
+a1=(1)
+a2=(1 2)
+a=(x y z w)
+a[500]=100
+a[1000]=100
+
+case $SH in
+bash|mksh)
+  typeset -p a0 a1 a2 a
+  exit ;;
+esac
+
+var a0 = _a2sp(a0)
+var a1 = _a2sp(a1)
+var a2 = _a2sp(a2)
+var sp = _a2sp(a)
+declare -p a0 a1 a2 sp
+
+## STDOUT:
+declare -a a0=()
+declare -a a1=([0]=1)
+declare -a a2=([0]=1 [1]=2)
+declare -a sp=([0]=x [1]=y [2]=z [3]=w [500]=100 [1000]=100)
+## END
+
+## OK bash STDOUT:
+declare -a a0=()
+declare -a a1=([0]="1")
+declare -a a2=([0]="1" [1]="2")
+declare -a a=([0]="x" [1]="y" [2]="z" [3]="w" [500]="100" [1000]="100")
+## END
+
+## OK mksh STDOUT:
+set -A a1
+typeset a1[0]=1
+set -A a2
+typeset a2[0]=1
+typeset a2[1]=2
+set -A a
+typeset a[0]=x
+typeset a[1]=y
+typeset a[2]=z
+typeset a[3]=w
+typeset a[500]=100
+typeset a[1000]=100
+## END
+
+## N-I zsh/ash STDOUT:
+## END


### PR DESCRIPTION
This PR implements `declare -p sp` for SparseArray

### Representation ([index]=value)

In this PR, I currently use the form `([index]=value)` for `declare -p`, but this form was exclusively used for the associative arrays before, AFAICR. However, I also remember that we now have osh and ysh where osh is more compatible with Bash. What is the current situation for the representation of `([index]=value)`? Can I use this form for the sparse-array representation (assuming that it will be implemented in the future)?

Or do we need to stick with `(); name[index]=value; ...`? There are still other places that want to use the string representation of a sparse-array value, but the usage of the form `(); name[index]=value` is limited as the second part `; ...` is only valid as "a command".

Another related discussion would be the mixed form `([begin_index]=val1 val2 val3 ...)`. I notice that there is a failing spec test (allowed failure) for it.

### Better function name?

I named the serialization function for the sparse array as `ToStrForAssignment`, but it might be better to name it as `ToStrShellEncode`, etc. I can follow if you have existing naming for this kind of function.