### PR TITLE
[test/spec] Add failing globstar tests

### DIFF
--- a/spec/globstar.test.sh
+++ b/spec/globstar.test.sh
@@ -22,9 +22,9 @@ shopt -s globstar
 mkdir -p c/subdir
 touch {leaf.md,c/leaf.md,c/subdir/leaf.md}
 
-echo **/*.* | tr ' ' '\n'
+echo **/*.* | tr ' ' '\n' | sort
 echo
-echo **/**/*.* | tr ' ' '\n'
+echo **/**/*.* | tr ' ' '\n' | sort
 ## STDOUT:
 c/leaf.md
 c/subdir/leaf.md
@@ -54,7 +54,7 @@ shopt -s globstar
 mkdir -p c/subdir
 touch c/subdir/leaf.md
 
-echo {**/*.*,} | sort -u | sed 's/[[:space:]]*$//'
+echo {**/*.*,} | sort | sed 's/[[:space:]]*$//'
 ## STDOUT:
 c/subdir/leaf.md
 ## END
@@ -66,11 +66,11 @@ mkdir directory
 touch leaf.md
 touch directory/leaf.md
 
-echo **/*.* | sort -u
-echo directory/**/*.md | sort -u
-echo d**/*.md | sort -u
-echo **y/*.md | sort -u
-echo d**y/*.md | sort -u
+echo **/*.* | sort
+echo directory/**/*.md | sort
+echo d**/*.md | sort
+echo **y/*.md | sort
+echo d**y/*.md | sort
 ## STDOUT:
 directory/leaf.md leaf.md
 directory/leaf.md
@@ -87,8 +87,8 @@ mkdir directory-2
 touch directory-2/leaf-2.md
 ln -s -T ../directory-2 directory-1/symlink
 
-echo **/*.* | sort -u
-echo ***/*.* | sort -u
+echo **/*.* | sort
+echo ***/*.* | sort
 ## STDOUT:
 directory-2/leaf-2.md
 directory-1/symlink/leaf-2.md directory-2/leaf-2.md

--- a/spec/globstar.test.sh
+++ b/spec/globstar.test.sh
@@ -22,15 +22,28 @@ shopt -s globstar
 mkdir -p c/subdir
 touch {leaf.md,c/leaf.md,c/subdir/leaf.md}
 
-echo **/*.* | tr ' ' '\n' | sort -u
+echo **/*.* | tr ' ' '\n'
 echo
-echo **/**/*.* | tr ' ' '\n' | sort -u
+echo **/**/*.* | tr ' ' '\n'
 ## STDOUT:
 c/leaf.md
 c/subdir/leaf.md
 leaf.md
 
 c/leaf.md
+c/subdir/leaf.md
+leaf.md
+## END
+
+## BUG zsh STDOUT:
+c/leaf.md
+c/subdir/leaf.md
+leaf.md
+
+c/leaf.md
+c/leaf.md
+c/subdir/leaf.md
+c/subdir/leaf.md
 c/subdir/leaf.md
 leaf.md
 ## END

--- a/spec/globstar.test.sh
+++ b/spec/globstar.test.sh
@@ -1,0 +1,84 @@
+## oils_failures_allowed: 4
+## compare_shells: bash zsh
+
+#### globstar is off -> ** is treated like *
+case $SH in zsh) exit ;; esac
+
+shopt -u globstar
+
+mkdir -p c/subdir
+touch {leaf.md,c/leaf.md,c/subdir/leaf.md}
+
+echo **/*.* | sort
+## STDOUT:
+c/leaf.md
+## END
+## N-I zsh STDOUT:
+## END
+
+#### each occurrence of ** recurses through all depths
+shopt -s globstar
+
+mkdir -p c/subdir
+touch {leaf.md,c/leaf.md,c/subdir/leaf.md}
+
+echo **/*.* | tr ' ' '\n' | sort -u
+echo
+echo **/**/*.* | tr ' ' '\n' | sort -u
+## STDOUT:
+c/leaf.md
+c/subdir/leaf.md
+leaf.md
+
+c/leaf.md
+c/subdir/leaf.md
+leaf.md
+## END
+
+#### within braces, globstar works when there is a comma
+shopt -s globstar
+
+mkdir -p c/subdir
+touch c/subdir/leaf.md
+
+echo {**/*.*,} | sort -u | sed 's/[[:space:]]*$//'
+## STDOUT:
+c/subdir/leaf.md
+## END
+
+#### ** behaves like * if adjacent to anything other than /
+shopt -s globstar
+
+mkdir directory
+touch leaf.md
+touch directory/leaf.md
+
+echo **/*.* | sort -u
+echo directory/**/*.md | sort -u
+echo d**/*.md | sort -u
+echo **y/*.md | sort -u
+echo d**y/*.md | sort -u
+## STDOUT:
+directory/leaf.md leaf.md
+directory/leaf.md
+directory/leaf.md
+directory/leaf.md
+directory/leaf.md
+## END
+
+#### in zsh, ***/ follows symlinked directories, while **/ does not
+case $SH in bash) exit ;; esac
+
+mkdir directory-1
+mkdir directory-2
+touch directory-2/leaf-2.md
+ln -s -T ../directory-2 directory-1/symlink
+
+echo **/*.* | sort -u
+echo ***/*.* | sort -u
+## STDOUT:
+directory-2/leaf-2.md
+directory-1/symlink/leaf-2.md directory-2/leaf-2.md
+## END
+## N-I bash STDOUT:
+## END

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -301,6 +301,10 @@ globignore() {
   run-file globignore "$@"
 }
 
+globstar() {
+  run-file globstar "$@"
+}
+
 arith() {
   run-file arith "$@"
 }


### PR DESCRIPTION
Related to #232.

Following what Ellen did in #1757, I had to use some restrictive naming (foo.md) in my test cases to work around the `_tmp` (?) subdirectory. I don't understand what the testing environment looks like: if indeed the current directory during test execution is the repo root, I would expect some of my globs to pick up, say, `osh/bool_stat.py`.