### PR TITLE
[refactor] Add `Bash{Array,Assoc}_ToStrForShellPrint` for `declare -p` and `set -x`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -6,7 +6,7 @@ from data_lang import j8_lite
 from mycpp import mops
 from mycpp import mylib
 
-from typing import List
+from typing import List, Optional
 
 
 #------------------------------------------------------------------------------
@@ -23,6 +23,62 @@ def BashArray_Length(array_val):
             length += 1
     return length
 
+def _BashArray_HasHoles(array_val):
+    # type: (value.BashArray) -> bool
+
+    # mycpp rewrite: None in array_val.strs
+    for s in array_val.strs:
+        if s is None:
+            return True
+    return False
+
+def BashArray_ToStrForShellPrint(array_val, name):
+    # type: (value.BashArray, Optional[str]) -> str
+
+    buff = []  # type: List[str]
+    first = True
+    if _BashArray_HasHoles(array_val):
+        if name is not None:
+            # Note: Arrays with unset elements are printed in the form:
+            #   declare -p arr=(); arr[3]='' arr[4]='foo' ...
+            # Note: This form will be deprecated in the future when
+            # InitializerList for the compound assignment a=([i]=v ...) is
+            # implemented.
+            buff.append("()")
+            for i, element in enumerate(array_val.strs):
+                if element is not None:
+                    if first:
+                        buff.append(";")
+                        first = False
+                    buff.extend([
+                        " ", name, "[", str(i), "]=",
+                        j8_lite.MaybeShellEncode(element)
+                    ])
+        else:
+            buff.append("(")
+            for i, element in enumerate(array_val.strs):
+                if element is not None:
+                    if not first:
+                        buff.append(" ")
+                    else:
+                        first = False
+                        buff.extend([
+                            "[", str(i), "]=",
+                            j8_lite.MaybeShellEncode(element)
+                        ])
+            buff.append(")")
+    else:
+        buff.append("(")
+        for element in array_val.strs:
+            if not first:
+                buff.append(" ")
+            else:
+                first = False
+            buff.append(j8_lite.MaybeShellEncode(element))
+        buff.append(")")
+
+    return ''.join(buff)
+
 #------------------------------------------------------------------------------
 # All BashAssoc operations depending on the internal
 # representation of SparseArray come here.
@@ -30,6 +86,25 @@ def BashArray_Length(array_val):
 def BashAssoc_Length(assoc_val):
     # type: (value.BashAssoc) -> int
     return len(assoc_val.d)
+
+def BashAssoc_ToStrForShellPrint(assoc_val):
+    # type: (value.BashAssoc) -> str
+
+    buff = ["("]  # type: List[str]
+    first = True
+    for key in sorted(assoc_val.d):
+        if not first:
+            buff.append(" ")
+        else:
+            first = False
+
+        key_quoted = j8_lite.ShellEncode(key)
+        value_quoted = j8_lite.MaybeShellEncode(assoc_val.d[key])
+
+        buff.extend(["[", key_quoted, "]=", value_quoted])
+
+    buff.append(")")
+    return ''.join(buff)
 
 #------------------------------------------------------------------------------
 # All SparseArray operations depending on the internal

--- a/core/dev.py
+++ b/core/dev.py
@@ -11,6 +11,7 @@ from _devbuild.gen.value_asdl import (value, value_e, value_t, sh_lvalue,
                                       sh_lvalue_e, LeftName)
 
 from core import error
+from core import bash_impl
 from core import optview
 from core import num
 from core import state
@@ -212,22 +213,11 @@ def _PrintShValue(val, buf):
 
         elif case(value_e.BashArray):
             val = cast(value.BashArray, UP_val)
-            parts = ['(']
-            for s in val.strs:
-                parts.append(j8_lite.MaybeShellEncode(s))
-            parts.append(')')
-            result = ' '.join(parts)
+            result = bash_impl.BashArray_ToStrForShellPrint(val, None)
 
         elif case(value_e.BashAssoc):
             val = cast(value.BashAssoc, UP_val)
-            parts = ['(']
-            for k, v in iteritems(val.d):
-                # key must be quoted
-                parts.append(
-                    '[%s]=%s' %
-                    (j8_lite.ShellEncode(k), j8_lite.MaybeShellEncode(v)))
-            parts.append(')')
-            result = ' '.join(parts)
+            result = bash_impl.BashAssoc_ToStrForShellPrint(val)
 
     buf.write(result)
 

--- a/spec/assign-extended.test.sh
+++ b/spec/assign-extended.test.sh
@@ -332,7 +332,7 @@ declare -p test_arr{1..7}
 ## STDOUT:
 declare -a test_arr1=()
 declare -a test_arr2=()
-declare -A test_arr3
+declare -A test_arr3=()
 declare -a test_arr4=(1 2 3)
 declare -a test_arr5=(1 2 3)
 declare -A test_arr6=(['a']=1 ['b']=2 ['c']=3)
@@ -422,7 +422,7 @@ f1
 [declare -pa]
 declare -a test_var6=()
 [declare -pA]
-declare -A test_var7
+declare -A test_var7=()
 ## END
 ## OK bash STDOUT:
 [declare -pa]


### PR DESCRIPTION
Note: This changes the result for an empty `BashAssoc`. We have been using `declare -A assoc` to mean an empty associative array while allowing `declare -A assoc=()` for *compatibility*. Now, this produces `declare -A assoc=()` for `declare -p assoc` to be consistent with Bash's output. **edit**: To explain the background, we want to call the ToStr function in [this form consistent with `BashArray`](https://github.com/oils-for-unix/oils/pull/2145/files#diff-828bd8642431550aea162b9540190291ce9f0cd52ce6b3c1041a09f585adbbe8R166), where the result is appended to `var_name=`. To append something to `declare -A assoc=` for an empty associative array, we need to use `()`.
