### PR TITLE
[refactor] Format array-related codes with `yapf`

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -132,7 +132,7 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
         if flag_x == '+' and cell.exported:
             continue
 
-        if flag_a and val.tag() not in [value_e.BashArray, value_e.SparseArray]:
+        if flag_a and val.tag() not in (value_e.BashArray, value_e.SparseArray):
             continue
         if flag_A and val.tag() != value_e.BashAssoc:
             continue
@@ -146,7 +146,7 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
                 flags.append('r')
             if cell.exported:
                 flags.append('x')
-            if val.tag() in [value_e.BashArray, value_e.SparseArray]:
+            if val.tag() in (value_e.BashArray, value_e.SparseArray):
                 flags.append('a')
             elif val.tag() == value_e.BashAssoc:
                 flags.append('A')
@@ -431,7 +431,7 @@ class NewVar(vm._AssignBuiltin):
             if rval is None and (arg.a or arg.A):
                 old_val = self.mem.GetValue(pair.var_name)
                 if arg.a:
-                    if old_val.tag() not in [value_e.BashArray, value_e.SparseArray]:
+                    if old_val.tag() not in (value_e.BashArray, value_e.SparseArray):
                         rval = value.BashArray([])
                 elif arg.A:
                     if old_val.tag() != value_e.BashAssoc:

--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -132,7 +132,8 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
         if flag_x == '+' and cell.exported:
             continue
 
-        if flag_a and val.tag() not in (value_e.BashArray, value_e.SparseArray):
+        if flag_a and val.tag() not in (value_e.BashArray,
+                                        value_e.SparseArray):
             continue
         if flag_A and val.tag() != value_e.BashAssoc:
             continue
@@ -163,15 +164,20 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
 
         elif val.tag() == value_e.BashArray:
             array_val = cast(value.BashArray, val)
-            decl.extend(["=", bash_impl.BashArray_ToStrForShellPrint(array_val, name)])
+            decl.extend(
+                ["=",
+                 bash_impl.BashArray_ToStrForShellPrint(array_val, name)])
 
         elif val.tag() == value_e.BashAssoc:
             assoc_val = cast(value.BashAssoc, val)
-            decl.extend(["=", bash_impl.BashAssoc_ToStrForShellPrint(assoc_val)])
+            decl.extend(
+                ["=", bash_impl.BashAssoc_ToStrForShellPrint(assoc_val)])
 
         elif val.tag() == value_e.SparseArray:
             sparse_val = cast(value.SparseArray, val)
-            decl.extend(["=", bash_impl.SparseArray_ToStrForShellPrint(sparse_val)])
+            decl.extend(
+                ["=",
+                 bash_impl.SparseArray_ToStrForShellPrint(sparse_val)])
 
         else:
             pass  # note: other types silently ignored
@@ -431,7 +437,8 @@ class NewVar(vm._AssignBuiltin):
             if rval is None and (arg.a or arg.A):
                 old_val = self.mem.GetValue(pair.var_name)
                 if arg.a:
-                    if old_val.tag() not in (value_e.BashArray, value_e.SparseArray):
+                    if old_val.tag() not in (value_e.BashArray,
+                                             value_e.SparseArray):
                         rval = value.BashArray([])
                 elif arg.A:
                     if old_val.tag() != value_e.BashAssoc:

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -8,10 +8,10 @@ from mycpp import mylib
 
 from typing import Dict, List, Optional
 
-
 #------------------------------------------------------------------------------
 # All BashArray operations depending on the internal
 # representation of SparseArray come here.
+
 
 def BashArray_Length(array_val):
     # type: (value.BashArray) -> int
@@ -23,15 +23,18 @@ def BashArray_Length(array_val):
             length += 1
     return length
 
+
 def BashArray_GetValues(array_val):
     # type: (value.BashArray) -> List[str]
 
     return array_val.strs
 
+
 def BashArray_AppendValues(array_val, strs):
     # type: (value.BashArray, List[str]) -> None
 
     array_val.strs.extend(strs)
+
 
 def _BashArray_HasHoles(array_val):
     # type: (value.BashArray) -> bool
@@ -41,6 +44,7 @@ def _BashArray_HasHoles(array_val):
         if s is None:
             return True
     return False
+
 
 def BashArray_ToStrForShellPrint(array_val, name):
     # type: (value.BashArray, Optional[str]) -> str
@@ -61,7 +65,8 @@ def BashArray_ToStrForShellPrint(array_val, name):
                         buff.append(";")
                         first = False
                     buff.extend([
-                        " ", name, "[", str(i), "]=",
+                        " ", name, "[",
+                        str(i), "]=",
                         j8_lite.MaybeShellEncode(element)
                     ])
         else:
@@ -73,7 +78,8 @@ def BashArray_ToStrForShellPrint(array_val, name):
                     else:
                         first = False
                         buff.extend([
-                            "[", str(i), "]=",
+                            "[",
+                            str(i), "]=",
                             j8_lite.MaybeShellEncode(element)
                         ])
             buff.append(")")
@@ -89,24 +95,29 @@ def BashArray_ToStrForShellPrint(array_val, name):
 
     return ''.join(buff)
 
+
 #------------------------------------------------------------------------------
 # All BashAssoc operations depending on the internal
 # representation of SparseArray come here.
 
+
 def BashAssoc_Length(assoc_val):
     # type: (value.BashAssoc) -> int
     return len(assoc_val.d)
+
 
 def BashAssoc_GetValues(assoc_val):
     # type: (value.BashAssoc) -> Dict[str, str]
 
     return assoc_val.d
 
+
 def BashAssoc_AppendValues(assoc_val, d):
     # type: (value.BashAssoc, Dict[str, str]) -> None
 
     for key in d.keys():
         assoc_val.d[key] = d[key]
+
 
 def BashAssoc_ToStrForShellPrint(assoc_val):
     # type: (value.BashAssoc) -> str
@@ -127,13 +138,16 @@ def BashAssoc_ToStrForShellPrint(assoc_val):
     buff.append(")")
     return ''.join(buff)
 
+
 #------------------------------------------------------------------------------
 # All SparseArray operations depending on the internal
 # representation of SparseArray come here.
 
+
 def SparseArray_Length(sparse_val):
     # type: (value.SparseArray) -> int
     return len(sparse_val.d)
+
 
 def SparseArray_GetKeys(sparse_val):
     # type: (value.SparseArray) -> List[mops.BigInt]
@@ -141,6 +155,7 @@ def SparseArray_GetKeys(sparse_val):
     keys = sparse_val.d.keys()
     mylib.BigIntSort(keys)
     return keys
+
 
 def SparseArray_GetValues(sparse_val):
     # type: (value.SparseArray) -> List[str]
@@ -155,21 +170,24 @@ def SparseArray_GetValues(sparse_val):
         values.append(sparse_val.d[index])
     return values
 
+
 def SparseArray_AppendValues(sparse_val, strs):
     # type: (value.SparseArray, List[str]) ->  None
     for s in strs:
         sparse_val.max_index = mops.Add(sparse_val.max_index, mops.ONE)
         sparse_val.d[sparse_val.max_index] = s
 
+
 def SparseArray_ToStrForShellPrint(sparse_val):
     # type: (value.SparseArray) -> str
 
-    body = [] # type: List[str]
+    body = []  # type: List[str]
     for index in SparseArray_GetKeys(sparse_val):
         if len(body) > 0:
             body.append(" ")
         body.extend([
-            "[", mops.ToStr(index), "]=",
+            "[",
+            mops.ToStr(index), "]=",
             j8_lite.MaybeShellEncode(sparse_val.d[index])
         ])
     return "(%s)" % ''.join(body)

--- a/core/state.py
+++ b/core/state.py
@@ -1975,7 +1975,8 @@ class Mem(object):
                         if index < 0:  # a[-1]++ computes this twice; could we avoid it?
                             index += n
                             if index < 0:
-                                e_die("Index %d is out of range" % lval.index, left_loc)
+                                e_die("Index %d is out of range" % lval.index,
+                                      left_loc)
 
                         if index < n:
                             strs[index] = rval.s

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -1030,8 +1030,9 @@ class BoolEvaluator(ArithEvaluator):
                 if index < 0:
                     index += n
                     if index < 0:
-                        e_die('-v got index %s, which is out of bounds for array of length %d' % (index_str, n),
-                              blame_loc)
+                        e_die(
+                            '-v got index %s, which is out of bounds for array of length %d'
+                            % (index_str, n), blame_loc)
                         return False
 
                 if index < n:


### PR DESCRIPTION
https://github.com/oils-for-unix/oils/pull/2148#issuecomment-2508810745

This pull request also includes the fix of `tag in [...]` in previous PRs to `tag in (...)` (acde2712e47d09f0401b48d1150e484df31c5f1d).