### PR TITLE
[bin] Fix bin name detection

### DIFF
--- a/bin/oils_for_unix.py
+++ b/bin/oils_for_unix.py
@@ -133,10 +133,11 @@ def AppBundleMain(argv):
 
     environ = pyos.Environ()
 
-    if applet in ('ysh', 'oil'):
+    if applet.startswith('ysh') or applet.startswith('oil'):
         return shell.Main('ysh', arg_r, environ, login_shell, loader, readline)
 
-    elif applet.endswith('sh'):  # sh, osh, bash imply OSH
+    elif applet.startswith('osh') or applet.endswith(
+            'sh'):  # sh, osh, bash imply OSH
         return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
 
     # For testing latency

--- a/bin/oils_for_unix.py
+++ b/bin/oils_for_unix.py
@@ -133,7 +133,7 @@ def AppBundleMain(argv):
 
     environ = pyos.Environ()
 
-    if applet.startswith('ysh') or applet.startswith('oil'):
+    if applet.startswith('ysh') or applet == 'oil':
         return shell.Main('ysh', arg_r, environ, login_shell, loader, readline)
 
     elif applet.startswith('osh') or applet.endswith(


### PR DESCRIPTION
When we have multiple binaries of oil/osh/ysh of different versions, we want to call these binaries through the names `osh-0.23.0`, `osh-0.24.0`, etc.  However, with the current implementation of switching the mode by the basename of the command, one cannot use those versioned names to call oil/osh/ysh.  This PR loosens the condition so that a prefix of the basename may match one of the command names.

- Another option is first to extract the prefix (e.g. `/^[[:alpha:]]+/`) from the variable `applet` (which contains the basename) and to match the prefix with the command names.
- Or even another possibility is to track the processing of the symbolic link resolution: list up all the basenames including the intermediate steps of the link resolution, and find the earliest matching name on the list. This doesn't work when the binary is set up by hard links.

Note: This PR would make the C++ version work, but the Python version still does not work because it tries to find related libraries based on the path `$0`.