### PR TITLE
[core] Improve error message of out-of-bound index

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -1975,8 +1975,9 @@ class Mem(object):
                         if index < 0:  # a[-1]++ computes this twice; could we avoid it?
                             index += n
                             if index < 0:
-                                e_die("Index %d is out of range" % lval.index,
-                                      left_loc)
+                                e_die(
+                                    "Index %d is out of bounds for array of length %d"
+                                    % (lval.index, n), left_loc)
 
                         if index < n:
                             strs[index] = rval.s

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -812,7 +812,7 @@ a[-1]=1
 ## STDERR:
   a[-1]=1
   ^~
-[ stdin ]:2: fatal: Index -1 is out of range
+[ stdin ]:2: fatal: Index -1 is out of bounds for array of length 0
 ## END
 
 ## OK bash STDERR:


### PR DESCRIPTION
This error message was introduced in #2137, but another error message introduced in the next https://github.com/oils-for-unix/oils/pull/2138#discussion_r1855493290 has been improved in https://github.com/oils-for-unix/oils/pull/2140#discussion_r1855505700.  This patch applies a similar improvement to the error message in #2137.
