### PR TITLE
[core] Fix silent out-of-range error in unsetting BashArray element

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -2292,12 +2292,16 @@ class Mem(object):
                 index = lval.index
                 if index < 0:
                     index += n
+                    if index < 0:
+                        e_die(
+                            "Index %d is out of bounds for array of length %d"
+                            % (lval.index, n))
 
                 if index == last_index:
                     # Special case: The array SHORTENS if you unset from the end.  You
                     # can tell with a+=(3 4)
                     strs.pop()
-                elif 0 <= index and index < last_index:
+                elif index < last_index:
                     strs[index] = None
                 else:
                     # If it's not found, it's not an error.  In other words, 'unset'

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -868,7 +868,7 @@ mksh: <stdin>[2]: syntax error: 'e[-1]' unexpected operator/operand
 
 
 #### a+=() modify existing instance of BashArray
-case $SH in mksh|bash) exit 0;; esac
+case $SH in mksh|bash) exit ;; esac
 
 a=(1 2 3)
 var b = a

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -883,3 +883,27 @@ b=(1 2 3 4 5)
 
 ## N-I mksh/bash STDOUT:
 ## END
+
+
+#### unset a[-2]: out-of-bound negative index should cause error
+case $SH in mksh) exit ;; esac
+
+a=(1)
+unset -v 'a[-2]'
+
+## status: 1
+## STDOUT:
+## END
+## STDERR:
+  unset -v 'a[-2]'
+  ^~~~~
+[ stdin ]:4: fatal: Index -2 is out of bounds for array of length 1
+## END
+
+## OK bash STDERR:
+bash: line 4: unset: [-2]: bad array subscript
+## END
+
+## N-I mksh status: 0
+## N-I mksh STDERR:
+## END


### PR DESCRIPTION
While Bash causes an error for `unset` with the invalid negative index,

```console
$ bash -c 'a=(1); unset -v "a[-2]"'
bash: line 1: unset: [-2]: bad array subscript
$ echo $?
1
```

the current `master` of `osh` succeeds silently:

```console
$ bin/osh -c 'a=(1); unset -v "a[-2]"'
$ echo $?
0
```

This patch adds the check and outputs an error message for the invalid negative index.
