### PR TITLE
[osh] Fix crash with `${a[@]: -(2*${#a[@]}+1)}`

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -399,15 +399,16 @@ def _PerformSlice(
             else:
                 i = begin
             strs = []  # type: List[str]
-            count = 0
-            while i < n:
-                if has_length and count == length:  # length could be 0
-                    break
-                s = orig[i]
-                if s is not None:  # Unset elements don't count towards the length
-                    strs.append(s)
-                    count += 1
-                i += 1
+            if i >= 0:
+                count = 0
+                while i < n:
+                    if has_length and count == length:  # length could be 0
+                        break
+                    s = orig[i]
+                    if s is not None:  # Unset elements don't count towards the length
+                        strs.append(s)
+                        count += 1
+                    i += 1
 
             result = value.BashArray(strs)
 

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -907,3 +907,27 @@ bash: line 4: unset: [-2]: bad array subscript
 ## N-I mksh status: 0
 ## N-I mksh STDERR:
 ## END
+
+
+#### out-of-bound negative offset for ${a[@]:offset}
+case $SH in mksh) exit ;; esac
+
+a=(1 2 3 4)
+echo "a=(${a[*]})"
+echo "begin=-1 -> (${a[*]: -1})"
+echo "begin=-2 -> (${a[*]: -2})"
+echo "begin=-3 -> (${a[*]: -3})"
+echo "begin=-4 -> (${a[*]: -4})"
+echo "begin=-5 -> (${a[*]: -5})"
+
+## STDOUT:
+a=(1 2 3 4)
+begin=-1 -> (4)
+begin=-2 -> (3 4)
+begin=-3 -> (2 3 4)
+begin=-4 -> (1 2 3 4)
+begin=-5 -> ()
+## END
+
+## N-I mksh STDOUT:
+## END


### PR DESCRIPTION
The current `master` crashes with the following command:

```console
$ bin/osh -c 'a=(1 2 3); echo "${a[@]: -7}"'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 201, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 170, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 140, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2091, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1890, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1728, in _Dispatch
    status = self._ExecuteList(node.children)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1967, in _ExecuteList
    status = self._Execute(child)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1890, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1617, in _Dispatch
    status = self._DoSimple(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 851, in _DoSimple
    allow_assign=True)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 2301, in EvalWordSequence2
    self._EvalWordToParts(w, part_vals, EXTGLOB_FILES)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1770, in _EvalWordToParts
    self._EvalWordPart(p, word_part_vals, eval_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1654, in _EvalWordPart
    self._EvalDoubleQuoted(part.parts, part_vals)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1174, in _EvalDoubleQuoted
    self._EvalWordPart(p, part_vals, QUOTED)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1678, in _EvalWordPart
    self._EvalBracedVarSub(part, part_vals, quoted)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1447, in _EvalBracedVarSub
    val = self._Slice(val, op, var_name, part)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 988, in _Slice
    val = _PerformSlice(val, begin, length, has_length, part, arg0_val)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 406, in _PerformSlice
    s = orig[i]
IndexError: list index out of range
```

It is not obvious how `${a[@]:offset}` should behave when `((offset < -${#a[@]}))`, but Bash silently produces an empty list.  In this patch, we make the behavior consistent with Bash.

