### PR TITLE
[mylib] Fix a code comment

### DIFF
--- a/mycpp/gc_mylib.cc
+++ b/mycpp/gc_mylib.cc
@@ -45,7 +45,7 @@ BigStr* JoinBytes(List<int>* byte_list) {
   return result;
 }
 
-// For BashArray
+// For SparseArray
 void BigIntSort(List<mops::BigInt>* keys) {
   keys->sort();
 }


### PR DESCRIPTION
`mylib.BigIntSort()` is introduced to sort the keys of `SparseArray`. It was first introduced to implement the methods in `func_misc.SparseOp`.  It is related to `SparseArray` rather than `BashArray`.  This patch fixes the code comment for `BigIntSort`.