### PR TITLE
[osh] Fix last element `${a[@]: -1}` after `unset -v a[-1]`

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -2302,6 +2302,8 @@ class Mem(object):
                     # Special case: The array SHORTENS if you unset from the end.  You
                     # can tell with a+=(3 4)
                     strs.pop()
+                    while len(strs) > 0 and strs[-1] is None:
+                        strs.pop()
                 elif index < last_index:
                     strs[index] = None
                 else:

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -931,3 +931,24 @@ begin=-5 -> ()
 
 ## N-I mksh STDOUT:
 ## END
+
+
+#### array length after unset
+case $SH in mksh) exit ;; esac
+
+a=(x)
+a[9]=y
+echo "len ${#a[@]};"
+
+unset -v 'a[-1]'
+echo "len ${#a[@]};"
+echo "last ${a[@]: -1};"
+
+## STDOUT:
+len 2;
+len 1;
+last x;
+## END
+
+## N-I mksh STDOUT:
+## END


### PR DESCRIPTION
In the current master, after unsetting the last element `unset -v a[-1]` when there is a hole before the last element, the subsequent call of array slice `${a[@]: -1}` fails to handle negative offset properly.

```console
$ bash -c 'a=(1); a[9]=x; unset -v "a[-1]"; echo "${a[@]: -1}"'
1
$ bin/osh -c 'a=(1); a[9]=x; unset -v "a[-1]"; echo "${a[@]: -1}"'

$
```
