### PR TITLE
[osh] Fix `${a[@]@Q}` crash with unset elements in array

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1029,8 +1029,11 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 elif case(value_e.BashArray):
                     array_val = cast(value.BashArray, UP_val)
 
-                    # TODO: should use fastfunc.ShellEncode
-                    tmp = [j8_lite.MaybeShellEncode(s) for s in array_val.strs]
+                    tmp = []  # type: List[str]
+                    for s in array_val.strs:
+                        if s is not None:
+                            # TODO: should use fastfunc.ShellEncode
+                            tmp.append(j8_lite.MaybeShellEncode(s))
                     result = value.Str(' '.join(tmp))
                 else:
                     e_die("Can't use @Q on %s" % ui.ValType(val), op)

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -952,3 +952,22 @@ last x;
 
 ## N-I mksh STDOUT:
 ## END
+
+
+#### Regression: ${a[@]@Q} crash with `a[0]=x a[2]=y`
+case $SH in mksh) exit ;; esac
+
+a[0]=x
+a[2]=y
+echo "quoted = (${a[@]@Q})"
+
+## STDOUT:
+quoted = (x y)
+## END
+
+## OK bash STDOUT:
+quoted = ('x' 'y')
+## END
+
+## N-I mksh STDOUT:
+## END

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -802,7 +802,8 @@ two=1
 ## N-I mksh STDOUT:
 ## END
 
-#### Assigning with out-of-range negative index
+
+#### Regression: Assigning with out-of-range negative index
 a=()
 a[-1]=1
 
@@ -825,7 +826,7 @@ bash: line 2: a[-1]: bad array subscript
 ## END
 
 
-#### Negative index in [[ -v a[index] ]]
+#### Regression: Negative index in [[ -v a[index] ]]
 a[0]=x
 a[5]=y
 a[10]=z
@@ -847,7 +848,7 @@ a has -11
 ## END
 
 
-#### Negative out-of-range index in [[ -v a[index] ]]
+#### Regression: Negative out-of-range index in [[ -v a[index] ]]
 e=()
 [[ -v e[-1] ]] && echo 'e has -1'
 
@@ -867,7 +868,7 @@ mksh: <stdin>[2]: syntax error: 'e[-1]' unexpected operator/operand
 ## END
 
 
-#### a+=() modify existing instance of BashArray
+#### a+=() modifies existing instance of BashArray
 case $SH in mksh|bash) exit ;; esac
 
 a=(1 2 3)
@@ -885,7 +886,7 @@ b=(1 2 3 4 5)
 ## END
 
 
-#### unset a[-2]: out-of-bound negative index should cause error
+#### Regression: unset a[-2]: out-of-bound negative index should cause error
 case $SH in mksh) exit ;; esac
 
 a=(1)
@@ -909,7 +910,7 @@ bash: line 4: unset: [-2]: bad array subscript
 ## END
 
 
-#### out-of-bound negative offset for ${a[@]:offset}
+#### Regression: Out-of-bound negative offset for ${a[@]:offset}
 case $SH in mksh) exit ;; esac
 
 a=(1 2 3 4)
@@ -933,7 +934,7 @@ begin=-5 -> ()
 ## END
 
 
-#### array length after unset
+#### Regression: Array length after unset
 case $SH in mksh) exit ;; esac
 
 a=(x)


### PR DESCRIPTION
The current `master` crashes with `${a[@]@Q}` when `a` has unset elements.

```console
$ bin/osh -c 'a=(x); a[2]=y; echo "${a[@]@Q}"'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 171, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 141, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2091, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1890, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1728, in _Dispatch
    status = self._ExecuteList(node.children)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1967, in _ExecuteList
    status = self._Execute(child)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1890, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1617, in _Dispatch
    status = self._DoSimple(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 851, in _DoSimple
    allow_assign=True)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 2302, in EvalWordSequence2
    self._EvalWordToParts(w, part_vals, EXTGLOB_FILES)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1771, in _EvalWordToParts
    self._EvalWordPart(p, word_part_vals, eval_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1655, in _EvalWordPart
    self._EvalDoubleQuoted(part.parts, part_vals)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1175, in _EvalDoubleQuoted
    self._EvalWordPart(p, part_vals, QUOTED)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1679, in _EvalWordPart
    self._EvalBracedVarSub(part, part_vals, quoted)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1427, in _EvalBracedVarSub
    val, quoted2 = self._Nullary(val, op, var_name)
  File "/home/murase/.mwg/git/oilshell/oil/osh/word_eval.py", line 1033, in _Nullary
    tmp = [j8_lite.MaybeShellEncode(s) for s in array_val.strs]
  File "/home/murase/.mwg/git/oilshell/oil/data_lang/j8_lite.py", line 38, in MaybeShellEncode
    if fastfunc.CanOmitQuotes(s):
TypeError: argument 1 must be string or read-only buffer, not None
```
