### PR TITLE
[core/state] Implement SparseArray `a[i]=v`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -162,6 +162,12 @@ def SparseArray_Length(sparse_val):
     return len(sparse_val.d)
 
 
+def SparseArray_MaxIndex(sparse_val):
+    # type: (value.SparseArray) -> mops.BigInt
+
+    return sparse_val.max_index
+
+
 def SparseArray_GetKeys(sparse_val):
     # type: (value.SparseArray) -> List[mops.BigInt]
 

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -6,7 +6,20 @@ from data_lang import j8_lite
 from mycpp import mops
 from mycpp import mylib
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+
+def BigInt_Greater(a, b):
+    # type: (mops.BigInt, mops.BigInt) -> bool
+
+    return mops.Greater(a, b)
+
+
+def BigInt_Less(a, b):
+    # type: (mops.BigInt, mops.BigInt) -> bool
+
+    return mops.Greater(b, a)
+
 
 #------------------------------------------------------------------------------
 # All BashArray operations depending on the internal
@@ -176,6 +189,37 @@ def SparseArray_AppendValues(sparse_val, strs):
     for s in strs:
         sparse_val.max_index = mops.Add(sparse_val.max_index, mops.ONE)
         sparse_val.d[sparse_val.max_index] = s
+
+
+def _SparseArray_CanonicalizeIndex(sparse_val, index):
+    # type: (value.SparseArray, mops.BigInt) -> Tuple[mops.BigInt, bool]
+    """This function returns None when the specified index is out of
+    range.  For example, when the index is negative and its absolute
+    value is larger than max_index + 1, it returns None.
+
+    """
+
+    if BigInt_Less(index, mops.ZERO):
+        index = mops.Add(index, mops.Add(sparse_val.max_index, mops.ONE))
+        if BigInt_Less(index, mops.ZERO):
+            return mops.MINUS_ONE, False
+    return index, True
+
+
+def SparseArray_SetElement(sparse_val, index, s):
+    # type: (value.SparseArray, mops.BigInt, str) -> int
+    """A non-zero return value represents an error code. If this
+    function returns 1, the specified index is out of range.
+
+    """
+
+    index, ok = _SparseArray_CanonicalizeIndex(sparse_val, index)
+    if not ok:
+        return 1  # error_code: out-of-range index
+    if BigInt_Greater(index, sparse_val.max_index):
+        sparse_val.max_index = index
+    sparse_val.d[index] = s
+    return 0
 
 
 def SparseArray_ToStrForShellPrint(sparse_val):

--- a/core/state.py
+++ b/core/state.py
@@ -1997,10 +1997,12 @@ class Mem(object):
                         error_code = bash_impl.SparseArray_SetElement(
                             lhs_sp, mops.BigInt(lval.index), rval.s)
                         if error_code == 1:
-                            n = bash_impl.SparseArray_Length(lhs_sp)
+                            n_big = mops.Add(
+                                bash_impl.SparseArray_MaxIndex(lhs_sp),
+                                mops.ONE)
                             e_die(
-                                "Index %d is out of bounds for array of length %d"
-                                % (lval.index, n), left_loc)
+                                "Index %d is out of bounds for array of length %s"
+                                % (lval.index, mops.ToStr(n_big)), left_loc)
                         return
 
                 # This could be an object, eggex object, etc.  It won't be

--- a/core/state.py
+++ b/core/state.py
@@ -20,6 +20,7 @@ from _devbuild.gen.value_asdl import (value, value_e, value_t, Obj, sh_lvalue,
                                       sh_lvalue_e, sh_lvalue_t, LeftName,
                                       y_lvalue_e, regex_match, regex_match_e,
                                       regex_match_t, RegexMatch)
+from core import bash_impl
 from core import error
 from core.error import e_usage, e_die
 from core import num
@@ -1989,6 +1990,17 @@ class Mem(object):
                             for i in xrange(n):
                                 strs.append(None)
                             strs[lval.index] = rval.s
+                        return
+
+                    elif case2(value_e.SparseArray):
+                        lhs_sp = cast(value.SparseArray, UP_cell_val)
+                        error_code = bash_impl.SparseArray_SetElement(
+                            lhs_sp, mops.BigInt(lval.index), rval.s)
+                        if error_code == 1:
+                            n = bash_impl.SparseArray_Length(lhs_sp)
+                            e_die(
+                                "Index %d is out of bounds for array of length %d"
+                                % (lval.index, n), left_loc)
                         return
 
                 # This could be an object, eggex object, etc.  It won't be

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -431,3 +431,25 @@ declare -a sp1=([10]=a [20]=b [99]=c [100]=1 [101]=2 [102]=3)
 
 ## N-I bash/zsh/mksh/ash STDOUT:
 ## END
+
+
+#### SparseArray: a[i]=v
+case $SH in bash|zsh|mksh|ash) exit ;; esac
+
+sp1[10]=a
+sp1[20]=b
+sp1[30]=c
+var sp1 = _a2sp(sp1)
+declare -p sp1
+sp1[10]=X
+sp1[25]=Y
+sp1[90]=Z
+declare -p sp1
+
+## STDOUT:
+declare -a sp1=([10]=a [20]=b [30]=c)
+declare -a sp1=([10]=X [20]=b [25]=Y [30]=c [90]=Z)
+## END
+
+## N-I bash/zsh/mksh/ash STDOUT:
+## END

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -453,3 +453,71 @@ declare -a sp1=([10]=X [20]=b [25]=Y [30]=c [90]=Z)
 
 ## N-I bash/zsh/mksh/ash STDOUT:
 ## END
+
+
+#### SparseArray: Negative index with a[i]=v
+case $SH in bash|zsh|mksh|ash) exit ;; esac
+
+sp1[9]=x
+var sp1 = _a2sp(sp1);
+
+declare -p sp1
+sp1[-1]=A
+sp1[-4]=B
+sp1[-8]=C
+sp1[-10]=D
+declare -p sp1
+
+## STDOUT:
+declare -a sp1=([9]=x)
+declare -a sp1=([0]=D [2]=C [6]=B [9]=A)
+## END
+
+## N-I bash/zsh/mksh/ash STDOUT:
+## END
+
+
+#### SparseArray: Negative out-of-bound index with a[i]=v (1/2)
+case $SH in bash|zsh|mksh|ash) exit ;; esac
+
+sp1[9]=x
+var sp1 = _a2sp(sp1);
+
+sp1[-11]=E
+declare -p sp1
+
+## status: 1
+## STDOUT:
+## END
+## STDERR:
+  sp1[-11]=E
+  ^~~~
+[ stdin ]:6: fatal: Index -11 is out of bounds for array of length 10
+## END
+
+## N-I bash/zsh/mksh/ash status: 0
+## N-I bash/zsh/mksh/ash STDERR:
+## END
+
+
+#### SparseArray: Negative out-of-bound index with a[i]=v (2/2)
+case $SH in bash|zsh|mksh|ash) exit ;; esac
+
+sp1[9]=x
+var sp1 = _a2sp(sp1);
+
+sp1[-21]=F
+declare -p sp1
+
+## status: 1
+## STDOUT:
+## END
+## STDERR:
+  sp1[-21]=F
+  ^~~~
+[ stdin ]:6: fatal: Index -21 is out of bounds for array of length 10
+## END
+
+## N-I bash/zsh/mksh/ash status: 0
+## N-I bash/zsh/mksh/ash STDERR:
+## END


### PR DESCRIPTION
BigInt operations for comparison are done through `bash_impl.BigInt_Less` as suggested in Ref. [1]

[1] https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/2024-11-22.20Meeting/near/485124692

## How should I return an error status?

For the result of `SparseArray_GetElement`, there are three possible cases:

- An element is found at the specified index. In this case, we return the value.
- No element is found at the specified index. In this case, we return `None`.
- The index is invalid. In particular, this happens when the index is too negative as `((index < -n))` (where `n` is the max index plus 1). I would like to return an error status this case, and let the caller determine how to handle it.

~~In the current PR,~~ In the planned PR for `SparseArray_GetElement`, I return a tuple `(str result, int error_code)` as the simplest approach, but this can be implemented in various ways.

- Another way is to return `(str result, bool has_error)` to just tell the existence of an error,
- Or reverting the meaning of `bool` from `has_error` to `success`, `(str result, bool success)`.
- Or something like `(str result, get_array_element_error_code_e error_code)` with `get_array_element_error_code_e` being an enum type to represent the error.
- One might even define a type as `GetElementResult = (str result, int error_code)`.
- Or is there already a way established in the Oils codebase?

**edit**: Oh, this PR is not about `SparseArray_GetElement` but about `SparseArray_SetElement`. Anyway, I want to discuss the same thing for `SparseArray_SetElement`.

For this PR, I now return `int error_code` for `SparseArray_SetElement`, but we have options in the same way as `SparseArray_GetElement` as discussed above.
