### PR TITLE
[core/dev] Fix xtrace output for `a+=(v)` and `declare a+=(v)`

### DIFF
--- a/core/dev.py
+++ b/core/dev.py
@@ -677,7 +677,7 @@ class Tracer(object):
         for pair in cmd_val.pairs:
             buf.write(' ')
             buf.write(pair.var_name)
-            buf.write('=')
+            buf.write('+=' if pair.plus_eq else '=')
             if pair.rval:
                 _PrintShValue(pair.rval, buf)
 

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -980,18 +980,20 @@ class CommandEvaluator(object):
 
                 # RHS can be a string or array.
                 if pair.rhs:
-                    val = self.word_ev.EvalRhsWord(pair.rhs)
-                    assert isinstance(val, value_t), val
+                    rhs = self.word_ev.EvalRhsWord(pair.rhs)
+                    assert isinstance(rhs, value_t), rhs
 
                 else:  # e.g. 'readonly x' or 'local x'
-                    val = None
+                    rhs = None
+
+                val = rhs
 
             # NOTE: In bash and mksh, declare -a myarray makes an empty cell
             # with Undef value, but the 'array' attribute.
 
             flags = 0  # for tracing
             self.mem.SetValue(lval, val, which_scopes, flags=flags)
-            self.tracer.OnShAssignment(lval, pair.op, val, flags, which_scopes)
+            self.tracer.OnShAssignment(lval, pair.op, rhs, flags, which_scopes)
 
         # PATCH to be compatible with existing shells: If the assignment had a
         # command sub like:

--- a/spec/xtrace.test.sh
+++ b/spec/xtrace.test.sh
@@ -384,3 +384,16 @@ declare a+=(2)
 ## END
 ## N-I dash/mksh STDERR:
 ## END
+
+
+#### Regression: xtrace for "a+=(v)"
+case $SH in dash|mksh) exit ;; esac
+
+a=(1)
+set -x
+a+=(2)
+## STDERR:
++ a+=(2)
+## END
+## N-I dash/mksh STDERR:
+## END

--- a/spec/xtrace.test.sh
+++ b/spec/xtrace.test.sh
@@ -367,3 +367,20 @@ ok
 [last=0] 'false'
 [last=1] echo ok
 ## END
+
+
+#### Regression: xtrace for "declare -a a+=(v)"
+case $SH in dash|mksh) exit ;; esac
+
+a=(1)
+set -x
+declare a+=(2)
+## STDERR:
++ declare a+=(2)
+## END
+## OK bash STDERR:
++ a+=('2')
++ declare a
+## END
+## N-I dash/mksh STDERR:
+## END


### PR DESCRIPTION
In the current `master`, xtrace outputs wrong commands for `a+=(v)` and `declare a+=(v)` in respective ways. Both are two different bugs. This PR fixes both.

### "`declare a=()`" for `declare a+=()`

For `declare a+=()`, xtrace does not consider the type of the assignment `=` vs `+=`.

```console
$ bin/osh -c 'set -x; declare a+=(v)'
+ declare a=(v)
```

829dddec0 fixes this problem.

### "`a+=(1 2)`" for `a+=(2)`

For `a+=(v)`, xtrace outputs the state of the array after the assignment as the value on the right-hand side.

```console
$ bin/osh -c 'a=(1); set -x; a+=(2)'
+ a+=(1 2)
```

8a586ab2d fixes this.
