### PR TITLE
[core refactor] Refactor the code for BashArray/BashAssoc `unset -v a[i]`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -198,6 +198,12 @@ def BashAssoc_SetElement(assoc_val, key, s):
     assoc_val.d[key] = s
 
 
+def BashAssoc_UnsetElement(assoc_val, key):
+    # type: (value.BashAssoc, str) -> None
+
+    mylib.dict_erase(assoc_val.d, key)
+
+
 def BashAssoc_ToStrForShellPrint(assoc_val):
     # type: (value.BashAssoc) -> str
 

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -80,6 +80,35 @@ def BashArray_SetElement(array_val, index, s):
     return 0
 
 
+def BashArray_UnsetElement(array_val, index):
+    # type: (value.BashArray, int) -> int
+    strs = array_val.strs
+
+    n = len(strs)
+    last_index = n - 1
+    if index < 0:
+        index += n
+        if index < 0:
+            return 1
+
+    if index == last_index:
+        # Special case: The array SHORTENS if you unset from the end.  You can
+        # tell with a+=(3 4)
+        strs.pop()
+        while len(strs) > 0 and strs[-1] is None:
+            strs.pop()
+    elif index < last_index:
+        strs[index] = None
+    else:
+        # If it's not found, it's not an error.  In other words, 'unset'
+        # ensures that a value doesn't exist, regardless of whether it existed.
+        # It's idempotent.  (Ousterhout specifically argues that the strict
+        # behavior was a mistake for Tcl!)
+        pass
+
+    return 0
+
+
 def _BashArray_HasHoles(array_val):
     # type: (value.BashArray) -> bool
 

--- a/core/state.py
+++ b/core/state.py
@@ -2302,7 +2302,7 @@ class Mem(object):
                 #  raise error.Runtime("%r isn't an associative array" % lval.name)
 
                 val = cast(value.BashAssoc, UP_val)
-                mylib.dict_erase(val.d, lval.key)
+                bash_impl.BashAssoc_UnsetElement(val, lval.key)
 
             else:
                 raise AssertionError(lval)

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -897,8 +897,8 @@ unset -v 'a[-2]'
 ## END
 ## STDERR:
   unset -v 'a[-2]'
-  ^~~~~
-[ stdin ]:4: fatal: Index -2 is out of bounds for array of length 1
+           ^
+[ stdin ]:4: a[-2]: Index is out of bounds for array of length 1
 ## END
 
 ## OK bash STDERR:


### PR DESCRIPTION
This moves the codes for `unset -v 'a[i]'`.