### PR TITLE
[refactor] Use `mops.IntWiden` for "int -> BigInt" conversion

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -1981,7 +1981,7 @@ class Mem(object):
                     elif case2(value_e.SparseArray):
                         lhs_sp = cast(value.SparseArray, UP_cell_val)
                         error_code = bash_impl.SparseArray_SetElement(
-                            lhs_sp, mops.BigInt(lval.index), rval.s)
+                            lhs_sp, mops.IntWiden(lval.index), rval.s)
                         if error_code == 1:
                             n_big = mops.Add(
                                 bash_impl.SparseArray_MaxIndex(lhs_sp),

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -438,7 +438,7 @@ class Reader(object):
         # type: (int) -> mops.BigInt
         val = self.OptionalValue()
         if val is None:
-            return mops.BigInt(default_)
+            return mops.IntWiden(default_)
         return self._ToInt(val)
 
     def PosFloat(self):
@@ -587,7 +587,7 @@ class Reader(object):
     def NamedInt(self, param_name, default_):
         # type: (str, int) -> mops.BigInt
         if param_name not in self.named_args:
-            return mops.BigInt(default_)
+            return mops.IntWiden(default_)
 
         val = self.named_args[param_name]
         UP_val = val

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -372,8 +372,8 @@ def _ParseOshInteger(s, blame_loc):
 
             # formula is:
             # integer = integer * base + digit
-            integer = mops.Add(mops.Mul(integer, mops.BigInt(base)),
-                               mops.BigInt(digit))
+            integer = mops.Add(mops.Mul(integer, mops.IntWiden(base)),
+                               mops.IntWiden(digit))
         return (True, integer)
 
     else:


### PR DESCRIPTION
https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/mops.2EBigInt.28i.29.20vs.2E.20mops.2EIntWiden.28i.29/near/485491602

`mops.BigInt(c)` for constants are intentionally left.