### PR TITLE
[refactor] Rename `${#arr[@]}` from `_Length` to `_Count`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -26,7 +26,7 @@ def BigInt_Less(a, b):
 # representation of SparseArray come here.
 
 
-def BashArray_Length(array_val):
+def BashArray_Count(array_val):
     # type: (value.BashArray) -> int
 
     # There can be empty placeholder values in the array.
@@ -139,7 +139,7 @@ def BashArray_ToStrForShellPrint(array_val, name):
 # representation of SparseArray come here.
 
 
-def BashAssoc_Length(assoc_val):
+def BashAssoc_Count(assoc_val):
     # type: (value.BashAssoc) -> int
     return len(assoc_val.d)
 
@@ -188,7 +188,7 @@ def BashAssoc_ToStrForShellPrint(assoc_val):
 # representation of SparseArray come here.
 
 
-def SparseArray_Length(sparse_val):
+def SparseArray_Count(sparse_val):
     # type: (value.SparseArray) -> int
     return len(sparse_val.d)
 

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -37,6 +37,12 @@ def BashArray_Count(array_val):
     return length
 
 
+def BashArray_Length(array_val):
+    # type: (value.BashArray) -> int
+
+    return len(array_val.strs)
+
+
 def BashArray_GetValues(array_val):
     # type: (value.BashArray) -> List[str]
 
@@ -193,10 +199,10 @@ def SparseArray_Count(sparse_val):
     return len(sparse_val.d)
 
 
-def SparseArray_MaxIndex(sparse_val):
+def SparseArray_Length(sparse_val):
     # type: (value.SparseArray) -> mops.BigInt
 
-    return sparse_val.max_index
+    return mops.Add(sparse_val.max_index, mops.ONE)
 
 
 def SparseArray_GetKeys(sparse_val):

--- a/core/state.py
+++ b/core/state.py
@@ -1972,7 +1972,7 @@ class Mem(object):
                         error_code = bash_impl.BashArray_SetElement(
                             cell_val, lval.index, rval.s)
                         if error_code == 1:
-                            n = bash_impl.BashArray_Length(cell_val)
+                            n = bash_impl.BashArray_Count(cell_val)
                             e_die(
                                 "Index %d is out of bounds for array of length %d"
                                 % (lval.index, n), left_loc)

--- a/core/state.py
+++ b/core/state.py
@@ -1972,7 +1972,7 @@ class Mem(object):
                         error_code = bash_impl.BashArray_SetElement(
                             cell_val, lval.index, rval.s)
                         if error_code == 1:
-                            n = bash_impl.BashArray_Count(cell_val)
+                            n = bash_impl.BashArray_Length(cell_val)
                             e_die(
                                 "Index %d is out of bounds for array of length %d"
                                 % (lval.index, n), left_loc)
@@ -1983,9 +1983,7 @@ class Mem(object):
                         error_code = bash_impl.SparseArray_SetElement(
                             lhs_sp, mops.BigInt(lval.index), rval.s)
                         if error_code == 1:
-                            n_big = mops.Add(
-                                bash_impl.SparseArray_MaxIndex(lhs_sp),
-                                mops.ONE)
+                            n_big = bash_impl.SparseArray_Length(lhs_sp)
                             e_die(
                                 "Index %d is out of bounds for array of length %s"
                                 % (lval.index, mops.ToStr(n_big)), left_loc)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -760,7 +760,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         else:
             raise AssertionError(tok.id)
 
-    def _Length(self, val, token):
+    def _Count(self, val, token):
         # type: (value_t, Token) -> int
         """Returns the length of the value, for ${#var}"""
         UP_val = val
@@ -774,7 +774,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
                 # https://stackoverflow.com/questions/17368067/length-of-string-in-bash
                 try:
-                    length = string_ops.CountUtf8Chars(val.s)
+                    count = string_ops.CountUtf8Chars(val.s)
                 except error.Strict as e:
                     # Add this here so we don't have to add it so far down the stack.
                     # TODO: It's better to show BOTH this CODE an the actual DATA
@@ -791,21 +791,21 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
             elif case(value_e.BashArray):
                 val = cast(value.BashArray, UP_val)
-                length = bash_impl.BashArray_Length(val)
+                count = bash_impl.BashArray_Count(val)
 
             elif case(value_e.BashAssoc):
                 val = cast(value.BashAssoc, UP_val)
-                length = bash_impl.BashAssoc_Length(val)
+                count = bash_impl.BashAssoc_Count(val)
 
             elif case(value_e.SparseArray):
                 val = cast(value.SparseArray, UP_val)
-                length = bash_impl.SparseArray_Length(val)
+                count = bash_impl.SparseArray_Count(val)
 
             else:
                 raise error.TypeErr(
                     val, "Length op expected Str, BashArray, BashAssoc", token)
 
-        return length
+        return count
 
     def _Keys(self, val, token):
         # type: (value_t, Token) -> value_t
@@ -1380,7 +1380,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 if not vsub_state.has_test_op:  # undef -> '' BEFORE length
                     val = self._EmptyStrOrError(val, part.token)
 
-                n = self._Length(val, part.token)
+                n = self._Count(val, part.token)
                 part_vals.append(Piece(str(n), quoted, False))
                 return  # EARLY EXIT: nothing else can come after length
 


### PR DESCRIPTION
I here suggest changing the name `_Length` to `_Count`. This is because there are two types of "lengths" in arrays.  One is the count of elements.  The other is the max index plus one.  They differ for sparse arrays.  For example, for an array constructed by `a=(); a[0]=x a[9]=y`, the former is 2, while the latter is 10.  This PR suggests calling the former "count", and the latter "length".

Ref: original discussion: https://github.com/oils-for-unix/oils/pull/2161#issuecomment-2510146764


This PR also contains the fix for the error message of a negative out-of-bound index. I added the "array length" to the error message of the negative array index in [\#2160 `core/state.py`](https://github.com/oils-for-unix/oils/pull/2160/files#diff-947c57d83e952ecdb670a97c89273b980cf665a12fd551ef0dc2e2d401593a90R1975), but that "length" was actually "count". Commit d9ca1a0d8c89543d43bccf22b334145b4f33d36d fixes it so that it uses the proper "length".