### PR TITLE
[osh] Check negative out-of-bound index for `${a[i]}` and `$((a[i]))`

### DIFF
--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -972,3 +972,39 @@ quoted = ('x' 'y')
 
 ## N-I mksh STDOUT:
 ## END
+
+
+#### Regression: silent out-of-bound negative index in ${a[-2]} and $((a[-2]))
+case $SH in mksh) exit ;; esac
+
+a=(x)
+echo "[${a[-2]}]"
+echo $?
+echo "[$((a[-2]))]"
+echo $?
+
+## STDOUT:
+[]
+0
+[0]
+0
+## END
+## STDERR:
+  echo "[${a[-2]}]"
+           ^
+[ stdin ]:4: Index -2 out of bounds for array of length 1
+  echo "[$((a[-2]))]"
+             ^
+[ stdin ]:6: Index -2 out of bounds for array of length 1
+## END
+
+## OK bash STDERR:
+bash: line 4: a: bad array subscript
+bash: line 6: a: bad array subscript
+## END
+
+## N-I mksh status: 0
+## N-I mksh STDOUT:
+## END
+## N-I mksh STDERR:
+## END


### PR DESCRIPTION
In the current master, they do not cause any error or warning.

```console
$ bin/osh -c 'a=(1); echo ${a[-2]}; echo $((a[-2]))'

0
```

while Bash produces warning messages (though they are just messages, and it does not cause any error):

```console
$ bash -c 'a=(1); echo ${a[-2]}; echo $((a[-2]))'
bash: line 1: a: bad array subscript

bash: line 1: a: bad array subscript
0
$
```

This PR checks the negative out-of-bound index in two cases `${a[i]}` and `$((a[-2]))` and outputs warning messages.
