### PR TITLE
Fix `bind -r` support with older readline fns

### DIFF
--- a/builtin/readline_osh.py
+++ b/builtin/readline_osh.py
@@ -138,10 +138,8 @@ class Bind(vm._Builtin):
                 if arg.u is not None:
                     readline.unbind_rl_function(arg.u)
 
-                if 0:
-                    # disabled until we fix error with rl_function_of_keyseq_len()
-                    if arg.r is not None:
-                        readline.unbind_keyseq(arg.r)
+                if arg.r is not None:
+                    readline.unbind_keyseq(arg.r)
 
                 if arg.x is not None:
                     self.errfmt.Print_("warning: bind -x isn't implemented",

--- a/pyext/line_input.c
+++ b/pyext/line_input.c
@@ -990,9 +990,6 @@ Print all bindings for shell commands in the current keymap.");
 static PyObject*
 unbind_keyseq(PyObject *self, PyObject *args)
 {
-    /* Disabled because of rl_function_of_keyseq_len() error */
-    Py_RETURN_NONE;
-#if 0
     char *seq, *keyseq;
     int kslen, type;
     rl_command_func_t *fn;
@@ -1000,37 +997,52 @@ unbind_keyseq(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s:unbind_keyseq", &seq))
         return NULL;
 
-    keyseq = (char *)malloc((2 * strlen(seq)) + 1);
-    if (rl_translate_keyseq(seq, keyseq, &kslen) != 0) {
-        free(keyseq);
-        PyErr_Format(PyExc_ValueError, "'%s': cannot translate key sequence", seq);
-        return NULL;
-    }
+    // Commented code below based on bash 5.x unbinding code, which fails on 
+    // readline versions before 2019.
 
-    fn = rl_function_of_keyseq_len(keyseq, kslen, (Keymap)NULL, &type);
-    if (!fn) {
-        free(keyseq);
-        Py_RETURN_NONE;
-    }
+    // keyseq = (char *)malloc((2 * strlen(seq)) + 1);
+    // if (rl_translate_keyseq(seq, keyseq, &kslen) != 0) {
+    //     free(keyseq);
+    //     PyErr_Format(PyExc_ValueError, "'%s': cannot translate key sequence", seq);
+    //     return NULL;
+    // }
 
-    if (type == ISKMAP) {
-        fn = ((Keymap)fn)[ANYOTHERKEY].function;
-    }
+    // fn = rl_function_of_keyseq_len(keyseq, kslen, (Keymap)NULL, &type);
+    // if (!fn) {
+    //     free(keyseq);
+    //     Py_RETURN_NONE;
+    // }
 
-    if (rl_bind_keyseq(seq, (rl_command_func_t *)NULL) != 0) {
-        free(keyseq);
+    // if (type == ISKMAP) {
+    //     fn = ((Keymap)fn)[ANYOTHERKEY].function;
+    // }
+
+    // if (rl_bind_keyseq(seq, (rl_command_func_t *)NULL) != 0) {
+    //     free(keyseq);
+    //     PyErr_Format(PyExc_ValueError, "'%s': cannot unbind", seq);
+    //     return NULL;
+    // }
+
+    // /* 
+    // TODO: Handle shell command unbinding if f == bash_execute_unix_command or
+    // rather, whatever the osh equivalent will be
+    // */
+
+    // free(keyseq);
+    // Py_RETURN_NONE;
+
+    // End bash 5.x unbinding code
+
+
+
+    // Code below based on bash 4 unbinding code from 2011
+
+    if (rl_bind_keyseq (seq, (rl_command_func_t *)NULL) != 0) {
         PyErr_Format(PyExc_ValueError, "'%s': cannot unbind", seq);
         return NULL;
     }
 
-    /* 
-    TODO: Handle shell command unbinding if f == bash_execute_unix_command or
-    rather, whatever the osh equivalent will be
-    */
-
-    free(keyseq);
     Py_RETURN_NONE;
-#endif
 }
 
 PyDoc_STRVAR(doc_unbind_keyseq,

--- a/spec/builtin-bind.test.sh
+++ b/spec/builtin-bind.test.sh
@@ -1,5 +1,5 @@
 ## oils_failures_allowed: 0
-## oils_cpp_failures_allowed: 3
+## oils_cpp_failures_allowed: 4
 ## compare_shells: bash
 
 # NB: This is only for NON-interactive tests of bind. 
@@ -78,4 +78,24 @@ vi-subst is not bound to any keys.
 status=1
 yank can be invoked via "\C-y".
 status=0
+## END
+
+
+#### bind -r 
+bind -q yank | grep -oF '\C-o\C-s\C-h'
+echo status=$?
+
+bind '"\C-o\C-s\C-h": yank'
+bind -q yank | grep -oF '\C-o\C-s\C-h'
+echo status=$?
+
+bind -r "\C-o\C-s\C-h"
+bind -q yank | grep -oF '\C-o\C-s\C-h'
+echo status=$?
+
+## STDOUT:
+status=1
+\C-o\C-s\C-h
+status=0
+status=1
 ## END

--- a/spec/stateful/bind.py
+++ b/spec/stateful/bind.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
-spec/stateful/bind.py
+Interactively tests shell bindings.
+
+To invoke this file, run the shell wrapper:
+
+    test/stateful.sh bind-quick
 """
 from __future__ import print_function
 


### PR DESCRIPTION
### About 
OK, this was pretty easy, as I suspected. The older method of unbinding still works; it's essentially like "binding" the keyseq to a null pointer, which readline interprets as wanting to remove the binding.

This is based off bash code added in 4.1 from 2011. The newer version is from bash 5.0 from 2019.

IIUC, this is slightly less efficient code, but no big deal. I left the newer code in place, but commented out. LMK if you want to remove it. Otherwise, I thought I'd delete it once the final pieces of bind -x are complete, and we're all done.

----

### Tests

I added a non-interactive test for `bind -r`. We can use `bind -q` to see what readline thinks the bindings are, but this can't test that the binding behavior is actually removed.

I incremented oils_cpp_failures_allowed, since I'm assuming the new test won't succeed, but lmk if that's wrong.

Since the interactive bind -r test uses a custom shell function, it's dependent on bind -x behavior, and so, still fails.