### PR TITLE
[core/bash_impl] Use `error_code_t` to return error

### DIFF
--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -163,6 +163,9 @@ module runtime
   #   inside them are stopped.
   job_state = Running | Done | Stopped
 
+  # core/bash_impl.py
+  error_code = OK | IndexOutOfRange
+
   # Flag arguments can be any of these types.
   flag_type = Bool | Int | Float | Str
 

--- a/core/state.py
+++ b/core/state.py
@@ -12,7 +12,7 @@ import time as time_  # avoid name conflict
 
 from _devbuild.gen.id_kind_asdl import Id
 from _devbuild.gen.option_asdl import option_i
-from _devbuild.gen.runtime_asdl import (scope_e, scope_t, Cell)
+from _devbuild.gen.runtime_asdl import (error_code_e, scope_e, scope_t, Cell)
 from _devbuild.gen.syntax_asdl import (loc, loc_t, Token, debug_frame,
                                        debug_frame_e, debug_frame_t)
 from _devbuild.gen.types_asdl import opt_group_i
@@ -1971,7 +1971,7 @@ class Mem(object):
                         cell_val = cast(value.BashArray, UP_cell_val)
                         error_code = bash_impl.BashArray_SetElement(
                             cell_val, lval.index, rval.s)
-                        if error_code == 1:
+                        if error_code == error_code_e.IndexOutOfRange:
                             n = bash_impl.BashArray_Length(cell_val)
                             e_die(
                                 "Index %d is out of bounds for array of length %d"
@@ -1982,7 +1982,7 @@ class Mem(object):
                         lhs_sp = cast(value.SparseArray, UP_cell_val)
                         error_code = bash_impl.SparseArray_SetElement(
                             lhs_sp, mops.IntWiden(lval.index), rval.s)
-                        if error_code == 1:
+                        if error_code == error_code_e.IndexOutOfRange:
                             n_big = bash_impl.SparseArray_Length(lhs_sp)
                             e_die(
                                 "Index %d is out of bounds for array of length %s"
@@ -2283,7 +2283,7 @@ class Mem(object):
                     val = cast(value.BashArray, UP_val)
                     error_code = bash_impl.BashArray_UnsetElement(
                         val, lval.index)
-                    if error_code == 1:
+                    if error_code == error_code_e.IndexOutOfRange:
                         n = bash_impl.BashArray_Length(val)
                         raise error.Runtime(
                             "%s[%d]: Index is out of bounds for array of length %d"
@@ -2292,7 +2292,7 @@ class Mem(object):
                     val = cast(value.SparseArray, UP_val)
                     error_code = bash_impl.SparseArray_UnsetElement(
                         val, mops.IntWiden(lval.index))
-                    if error_code == 1:
+                    if error_code == error_code_e.IndexOutOfRange:
                         big_length = bash_impl.SparseArray_Length(val)
                         raise error.Runtime(
                             "%s[%d]: Index is out of bounds for array of length %s"

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -11,7 +11,7 @@ sh_expr_eval.py -- Shell boolean and arithmetic expressions.
 from __future__ import print_function
 
 from _devbuild.gen.id_kind_asdl import Id
-from _devbuild.gen.runtime_asdl import scope_t
+from _devbuild.gen.runtime_asdl import error_code_e, scope_t
 from _devbuild.gen.syntax_asdl import (
     word_t,
     CompoundWord,
@@ -736,7 +736,7 @@ class ArithEvaluator(object):
                                 self.EvalToBigInt(node.right))
                             s, error_code = word_eval.GetArrayItem(
                                 array_val.strs, small_i)
-                            if error_code == 1:
+                            if error_code == error_code_e.IndexOutOfRange:
                                 # Note: Bash outputs warning but does not make
                                 # it a real error.  We follow the Bash behavior
                                 # here.
@@ -1041,7 +1041,7 @@ class BoolEvaluator(ArithEvaluator):
                     return False
 
                 result, error_code = bash_impl.BashArray_HasElement(val, index)
-                if error_code == 1:
+                if error_code == error_code_e.IndexOutOfRange:
                     e_die(
                         '-v got index %s, which is out of bounds for array of length %d'
                         % (index_str, bash_impl.BashArray_Length(val)),

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -33,6 +33,8 @@ from _devbuild.gen.runtime_asdl import (
     cmd_value,
     cmd_value_e,
     cmd_value_t,
+    error_code_e,
+    error_code_t,
     AssignArg,
     a_index,
     a_index_e,
@@ -125,13 +127,13 @@ def DecayArray(val):
 
 
 def GetArrayItem(strs, index):
-    # type: (List[str], int) -> Tuple[Optional[str], int]
+    # type: (List[str], int) -> Tuple[Optional[str], error_code_t]
 
     n = len(strs)
     if index < 0:
         index += n
         if index < 0:
-            return None, 1
+            return None, error_code_e.IndexOutOfRange
 
     if index < n:
         # TODO: strs->index() has a redundant check for (i < 0)
@@ -139,7 +141,7 @@ def GetArrayItem(strs, index):
         # note: s could be None because representation is sparse
     else:
         s = None
-    return s, 0
+    return s, error_code_e.OK
 
 
 def _DetectMetaBuiltinStr(s):
@@ -1123,7 +1125,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 vtest_place.index = a_index.Int(index)
 
                 s, error_code = GetArrayItem(array_val.strs, index)
-                if error_code == 1:
+                if error_code == error_code_e.IndexOutOfRange:
                     # Note: Bash outputs warning but does not make it a real
                     # error.  We follow the Bash behavior here.
                     self.errfmt.Print_(


### PR DESCRIPTION
> https://github.com/oils-for-unix/oils/pull/2167#discussion_r1866878249
>
> Also I think it would be nice to have
> 
> `if error == bash_impl.IndexOutOfRange`
> 
> instead of hard-coding `1` . Then we don't need the comment, and it is more readable

This introduces an enum type to return the error status of a negative out-of-bound index of indexed arrays. To add the enum, I added `error_code = OK | IndexOutOfRange` in `runtime.asdl` (which may be extended to include other types of errors in the future). If there is a better way, please let me know.

