### PR TITLE
[osh] Refactor BashArray/BashAssoc `${arr[i]}`, `$((arr[i]))`, and `$arr`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -72,6 +72,31 @@ def BashArray_HasElement(val, index):
     return False, error_code_e.OK
 
 
+def BashArray_GetElement(array_val, index):
+    # type: (value.BashArray, int) -> Tuple[Optional[str], error_code_t]
+    """This function returns a tuple of a string value and an
+    error_code.  If the element is found, the value is returned as the
+    first element of the tuple.  Otherwise, the first element of the
+    tuple is None.
+
+    """
+
+    strs = array_val.strs
+    n = len(strs)
+    if index < 0:
+        index += n
+        if index < 0:
+            return None, error_code_e.IndexOutOfRange
+
+    if index < n:
+        # TODO: strs->index() has a redundant check for (i < 0)
+        s = strs[index]
+        # note: s could be None because representation is sparse
+    else:
+        s = None
+    return s, error_code_e.OK
+
+
 def BashArray_SetElement(array_val, index, s):
     # type: (value.BashArray, int, str) -> error_code_t
 

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -240,6 +240,12 @@ def BashAssoc_HasElement(assoc_val, s):
     return s in assoc_val.d
 
 
+def BashAssoc_GetElement(assoc_val, s):
+    # type: (value.BashAssoc, str) -> Optional[str]
+
+    return assoc_val.d.get(s)
+
+
 def BashAssoc_SetElement(assoc_val, key, s):
     # type: (value.BashAssoc, str, str) -> None
 

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -170,10 +170,10 @@ def OldValue(lval, mem, exec_opts):
                     tmp2 = cast(value.BashAssoc, UP_val)
                     # mycpp rewrite: add tmp.  cast() creates a new var in inner scope
                     assoc_val = tmp2
+                    s = bash_impl.BashAssoc_GetElement(assoc_val, lval.key)
                 else:
                     e_die("Can't use [] on value of type %s" % ui.ValType(val))
 
-            s = assoc_val.d.get(lval.key)
             if s is None:
                 val = value.Str('')
             else:
@@ -746,7 +746,7 @@ class ArithEvaluator(object):
                         elif case(value_e.BashAssoc):
                             left = cast(value.BashAssoc, UP_left)
                             key = self.EvalWordToString(node.right)
-                            s = left.d.get(key)
+                            s = bash_impl.BashAssoc_GetElement(left, key)
 
                         elif case(value_e.Str):
                             left = cast(value.Str, UP_left)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -34,7 +34,6 @@ from _devbuild.gen.runtime_asdl import (
     cmd_value_e,
     cmd_value_t,
     error_code_e,
-    error_code_t,
     AssignArg,
     a_index,
     a_index_e,
@@ -124,24 +123,6 @@ def DecayArray(val):
         return value.Undef
     else:
         return value.Str(s)
-
-
-def GetArrayItem(strs, index):
-    # type: (List[str], int) -> Tuple[Optional[str], error_code_t]
-
-    n = len(strs)
-    if index < 0:
-        index += n
-        if index < 0:
-            return None, error_code_e.IndexOutOfRange
-
-    if index < n:
-        # TODO: strs->index() has a redundant check for (i < 0)
-        s = strs[index]
-        # note: s could be None because representation is sparse
-    else:
-        s = None
-    return s, error_code_e.OK
 
 
 def _DetectMetaBuiltinStr(s):
@@ -1124,7 +1105,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 index = self.arith_ev.EvalToInt(anode)
                 vtest_place.index = a_index.Int(index)
 
-                s, error_code = GetArrayItem(array_val.strs, index)
+                s, error_code = bash_impl.BashArray_GetElement(
+                    array_val, index)
                 if error_code == error_code_e.IndexOutOfRange:
                     # Note: Bash outputs warning but does not make it a real
                     # error.  We follow the Bash behavior here.

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -112,10 +112,14 @@ def DecayArray(val):
     """Resolve ${array} to ${array[0]}."""
     if val.tag() == value_e.BashArray:
         array_val = cast(value.BashArray, val)
-        s = array_val.strs[0] if len(array_val.strs) else None
+        s, error_code = bash_impl.BashArray_GetElement(array_val, 0)
+
+        # Note: index 0 should never cause the out-of-bound index error.
+        assert error_code == error_code_e.OK
+
     elif val.tag() == value_e.BashAssoc:
         assoc_val = cast(value.BashAssoc, val)
-        s = assoc_val.d['0'] if '0' in assoc_val.d else None
+        s = bash_impl.BashAssoc_GetElement(assoc_val, '0')
     else:
         raise AssertionError(val.tag())
 

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1128,7 +1128,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                     anode, blame_loc=location.TokenForArith(anode))
 
                 vtest_place.index = a_index.Str(key)  # out param
-                s = assoc_val.d.get(key)
+                s = bash_impl.BashAssoc_GetElement(assoc_val, key)
 
                 if s is None:
                     val = value.Undef


### PR DESCRIPTION
This PR includes four commits.

- 81c37b43a7d2ae466f9dc517e134e367105a6556 renames an existing function `word_eval.GetArrayItem` to `bash_impl.BashArray_GetElement`.
- 6315b5d3fd8c357411cd7341747823370dd0221a adds `BashAssoc_GetElement` and uses it for `${assoc[key]}` and `$((assoc[key]))`.
- b0b16916c98d8a4552aaad30a6d7848f6c51bca6 uses `Bash{Array,Assoc}_GetElement` for `$arr` (which is equivalent to `${arr[0]}`).
- 9b7b2e3ee08f46ff389733df7d6476df57c25f78 is a refactoring of `bash_impl` using a new function `_BashArray_CanonicalizeIndex` (similar to the one for sparse arrays).