### PR TITLE
[refactor] Explicitly let BashAssoc/SparseArray pass through for `${a[@]}`

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1060,7 +1060,6 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
         if op_id == Id.Lit_At:
             vsub_state.join_array = not quoted  # ${a[@]} decays but "${a[@]}" doesn't
-            UP_val = val
             with tagswitch(val) as case2:
                 if case2(value_e.Undef):
                     if not vsub_state.has_test_op:

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1078,7 +1078,10 @@ class AbstractWordEvaluator(StringWordEvaluator):
             elif case2(value_e.BashArray, value_e.SparseArray, value_e.BashAssoc):
                 pass  # no-op
             else:
-                raise AssertionError(op_id)  # unknown
+                # The other YSH types such as List, Dict, and Float are not
+                # supported.  Error messages will be printed later, so we here
+                # return the unsupported objects without modification.
+                pass  # no-op
 
         return val
 

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1059,31 +1059,24 @@ class AbstractWordEvaluator(StringWordEvaluator):
         op_id = cast(bracket_op.WholeArray, part.bracket_op).op_id
 
         if op_id == Id.Lit_At:
+            op_str = '@'
             vsub_state.join_array = not quoted  # ${a[@]} decays but "${a[@]}" doesn't
-            with tagswitch(val) as case2:
-                if case2(value_e.Undef):
-                    if not vsub_state.has_test_op:
-                        val = self._EmptyBashArrayOrError(part.token)
-                elif case2(value_e.Str):
-                    if self.exec_opts.strict_array():
-                        e_die("Can't index string with @", loc.WordPart(part))
-                elif case2(value_e.BashArray):
-                    pass  # no-op
-
         elif op_id == Id.Arith_Star:
+            op_str = '*'
             vsub_state.join_array = True  # both ${a[*]} and "${a[*]}" decay
-            with tagswitch(val) as case2:
-                if case2(value_e.Undef):
-                    if not vsub_state.has_test_op:
-                        val = self._EmptyBashArrayOrError(part.token)
-                elif case2(value_e.Str):
-                    if self.exec_opts.strict_array():
-                        e_die("Can't index string with *", loc.WordPart(part))
-                elif case2(value_e.BashArray):
-                    pass  # no-op
-
         else:
             raise AssertionError(op_id)  # unknown
+
+        with tagswitch(val) as case2:
+            if case2(value_e.Undef):
+                if not vsub_state.has_test_op:
+                    val = self._EmptyBashArrayOrError(part.token)
+            elif case2(value_e.Str):
+                if self.exec_opts.strict_array():
+                    e_die("Can't index string with %s" % op_str,
+                          loc.WordPart(part))
+            elif case2(value_e.BashArray):
+                pass  # no-op
 
         return val
 

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1075,8 +1075,10 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 if self.exec_opts.strict_array():
                     e_die("Can't index string with %s" % op_str,
                           loc.WordPart(part))
-            elif case2(value_e.BashArray):
+            elif case2(value_e.BashArray, value_e.SparseArray, value_e.BashAssoc):
                 pass  # no-op
+            else:
+                raise AssertionError(op_id)  # unknown
 
         return val
 


### PR DESCRIPTION
This does not change the behavior, but it is inconsistent that `BashAssoc` is not checked, while `BashArray` is explicitly checked. `BashAssoc` has been slipped off from the type check due to the missing `else:` branches.

**edit**: This PR also contains commits for removing unused variable (3016835c08bcc5f31fa964fedde1349b8e0ef296) and reducing the mostly identical code (b82072650427848e2cb38a299721f99e11aef0a5).

**edit**: I realized that non-OSH/Bash objects (such as `List`, `Dict`, and `Float`) may go through this function in YSH even though `${a[@]}`, etc. are not supported for those objects. In commit 88301b1d5618406941e75b9f1a9d97cab8b2ce2f, I changed the check to be permissive for unknown types with a code comment.

