### PR TITLE
[refactor] Use `Optional[str]` instead of `str` when `None` is possible

### DIFF
--- a/builtin/func_misc.py
+++ b/builtin/func_misc.py
@@ -650,7 +650,7 @@ class SparseOp(vm._Callable):
         #i = mops.BigTruncate(rd.PosInt())
         op_name = rd.PosStr()
 
-        no_str = None  # type: str
+        no_str = None  # type: Optional[str]
 
         if op_name == 'len':  # ${#a[@]}
             rd.Done()

--- a/builtin/method_str.py
+++ b/builtin/method_str.py
@@ -19,7 +19,7 @@ from ysh import val_ops
 import libc
 from libc import REG_NOTBOL
 
-from typing import cast, Dict, List, Tuple
+from typing import cast, Dict, List, Optional, Tuple
 
 _ = log
 
@@ -130,7 +130,7 @@ class HasAffix(vm._Callable):
 
         string = rd.PosStr()
         pattern_val = rd.PosValue()
-        pattern_str = None  # type: str
+        pattern_str = None  # type: Optional[str]
         pattern_eggex = None  # type: value.Eggex
         with tagswitch(pattern_val) as case:
             if case(value_e.Eggex):
@@ -187,7 +187,7 @@ class Trim(vm._Callable):
 
         string = rd.PosStr()
         pattern_val = rd.OptionalValue()
-        pattern_str = None  # type: str
+        pattern_str = None  # type: Optional[str]
         pattern_eggex = None  # type: value.Eggex
         if pattern_val:
             with tagswitch(pattern_val) as case:
@@ -425,7 +425,7 @@ class Replace(vm._Callable):
                     break
 
                 # Collect captures
-                arg0 = None  # type: str
+                arg0 = None  # type: Optional[str]
                 argv = []  # type: List[str]
                 named_vars = {}  # type: Dict[str, value_t]
                 num_groups = len(indices) / 2
@@ -507,7 +507,7 @@ class Split(vm._Callable):
         """
         string = rd.PosStr()
 
-        string_sep = None  # type: str
+        string_sep = None  # type: Optional[str]
         eggex_sep = None  # type: value.Eggex
 
         sep = rd.PosValue()

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -102,7 +102,7 @@ def BashArray_GetElement(array_val, index):
 
     if index < n:
         # TODO: strs->index() has a redundant check for (i < 0)
-        s = array_val.strs[index]
+        s = array_val.strs[index]  # type: Optional[str]
         # note: s could be None because representation is sparse
     else:
         s = None

--- a/core/completion.py
+++ b/core/completion.py
@@ -320,9 +320,9 @@ class Api(object):
         self.line = line
         self.begin = begin
         self.end = end
-        self.first = None  # type: str
-        self.to_complete = None  # type: str
-        self.prev = None  # type: str
+        self.first = None  # type: Optional[str]
+        self.to_complete = None  # type: Optional[str]
+        self.prev = None  # type: Optional[str]
         self.index = -1  # type: int
         self.partial_argv = []  # type: List[str]
         # NOTE: COMP_WORDBREAKS is initialized in Mem().
@@ -1182,7 +1182,7 @@ class RootCompleter(object):
         # Used on retries.
         partial_argv = []  # type: List[str]
         num_partial = -1
-        first = None  # type: str
+        first = None  # type: Optional[str]
 
         if len(trail.words) > 0:
             # Now check if we're completing a word!
@@ -1225,7 +1225,7 @@ class RootCompleter(object):
                 num_partial = len(partial_argv)
 
                 first = partial_argv[0]
-                alias_first = None  # type: str
+                alias_first = None  # type: Optional[str]
                 if mylib.PYTHON:
                     debug_f.writeln('alias_words: [%s]' % trail.alias_words)
 

--- a/frontend/reader.py
+++ b/frontend/reader.py
@@ -205,7 +205,7 @@ class InteractiveLineReader(_Reader):
         self.line_input = line_input
         self.prompt_state = prompt_state
 
-        self.prev_line = None  # type: str
+        self.prev_line = None  # type: Optional[str]
         self.prompt_str = ''
 
         self.Reset()

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -947,7 +947,7 @@ class ArithEvaluator(object):
                 var_name = self.EvalWordToString(w)
                 return (var_name, w)
 
-        no_str = None  # type: str
+        no_str = None  # type: Optional[str]
         return (no_str, loc.Missing)
 
     def EvalArithLhs(self, anode):

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -141,7 +141,7 @@ def OldValue(lval, mem, exec_opts):
 
             with tagswitch(val) as case2:
                 if case2(value_e.Undef):
-                    s = None  # type: str
+                    s = None  # type: Optional[str]
                 elif case2(value_e.BashArray):
                     array_val = cast(value.BashArray, UP_val)
                     s, _ = bash_impl.BashArray_GetElement(

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -1420,7 +1420,7 @@ class EggexEvaluator(object):
         UP_term = term
 
         # These 2 vars will be initialized if we don't return early
-        s = None  # type: str
+        s = None  # type: Optional[str]
         char_code_tok = None  # type: Token
 
         with tagswitch(term) as case:

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -522,7 +522,7 @@ def MatchRegex(left, right, mem):
                                 loc.Missing)
 
     UP_left = left
-    left_s = None  # type: str
+    left_s = None  # type: Optional[str]
     with tagswitch(left) as case:
         if case(value_e.Str):
             left = cast(value.Str, UP_left)


### PR DESCRIPTION
https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/2024-11-22.20Meeting/near/486625799

There are two declarations of the form `v = None  # type: str` and `v = None  # type: Optional[str]`. This PR unifies them to `v = None  # type: Optional[str]`.


- 35481d91f1b476f248dacda352e157197d91c3e7 is fixes for the codes I contributed.
- 9493b3b1d is the fixes for the trivial case: rewriting from `= None  # type: str` to `= None  # type: Optioanl[str]`

I tried to find non-trivial cases where the variable is first assigned with an object and then with `None`, but it seems in most cases, the object assigned first has a class type. I haven't checked all the files, but I decided not to fix these non-trivial cases within this PR.
