### PR TITLE
[osh refactor] Refactor BashArray/BashAssoc `$*`, `${a[@]}`, `${a[@]#...}`, `${a[@]//pat/sub}`, `${a[@]:offset:len}`, and `${a[@]@Q}`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -244,6 +244,12 @@ def BashAssoc_AppendDict(assoc_val, d):
         assoc_val.d[key] = d[key]
 
 
+def BashAssoc_GetValues(assoc_val):
+    # type: (value.BashAssoc) -> List[str]
+
+    return assoc_val.d.values()
+
+
 def BashAssoc_HasElement(assoc_val, s):
     # type: (value.BashAssoc, str) -> bool
 

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -231,13 +231,13 @@ def BashAssoc_Count(assoc_val):
     return len(assoc_val.d)
 
 
-def BashAssoc_GetValues(assoc_val):
+def BashAssoc_GetDict(assoc_val):
     # type: (value.BashAssoc) -> Dict[str, str]
 
     return assoc_val.d
 
 
-def BashAssoc_AppendValues(assoc_val, d):
+def BashAssoc_AppendDict(assoc_val, d):
     # type: (value.BashAssoc, Dict[str, str]) -> None
 
     for key in d:

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -246,8 +246,8 @@ def PlusEquals(old_val, val):
             elif tag == value_e.BashAssoc:
                 assoc_lhs = cast(value.BashAssoc, UP_old_val)
                 assoc_rhs = cast(value.BashAssoc, UP_val)
-                d = bash_impl.BashAssoc_GetValues(assoc_rhs)
-                bash_impl.BashAssoc_AppendValues(assoc_lhs, d)
+                d = bash_impl.BashAssoc_GetDict(assoc_rhs)
+                bash_impl.BashAssoc_AppendDict(assoc_lhs, d)
                 val = assoc_lhs
 
             else:

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1013,12 +1013,12 @@ class AbstractWordEvaluator(StringWordEvaluator):
                     quoted2 = True
                 elif case(value_e.BashArray):
                     array_val = cast(value.BashArray, UP_val)
-
-                    tmp = []  # type: List[str]
-                    for s in array_val.strs:
-                        if s is not None:
-                            # TODO: should use fastfunc.ShellEncode
-                            tmp.append(j8_lite.MaybeShellEncode(s))
+                    tmp = [
+                        # TODO: should use fastfunc.ShellEncode
+                        j8_lite.MaybeShellEncode(s)
+                        for s in bash_impl.BashArray_GetValues(array_val)
+                        if s is not None
+                    ]
                     result = value.Str(' '.join(tmp))
                 else:
                     e_die("Can't use @Q on %s" % ui.ValType(val), op)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1181,7 +1181,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         """Decay $* to a string."""
         assert val.tag() == value_e.BashArray, val
         sep = self.splitter.GetJoinChar()
-        tmp = [s for s in val.strs if s is not None]
+        tmp = [s for s in bash_impl.BashArray_GetValues(val) if s is not None]
         return value.Str(sep.join(tmp))
 
     def _EmptyStrOrError(self, val, token):

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -216,12 +216,12 @@ def _ValueToPartValue(val, quoted, part_loc):
 
         elif case(value_e.BashArray):
             val = cast(value.BashArray, UP_val)
-            return part_value.Array(val.strs)
+            return part_value.Array(bash_impl.BashArray_GetValues(val))
 
         elif case(value_e.BashAssoc):
             val = cast(value.BashAssoc, UP_val)
             # bash behavior: splice values!
-            return part_value.Array(val.d.values())
+            return part_value.Array(bash_impl.BashAssoc_GetValues(val))
 
         # Cases added for YSH
         # value_e.List is also here - we use val_ops.Stringify()s err message

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -935,19 +935,16 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 s = replacer.Replace(str_val.s, op)
                 val = value.Str(s)
 
-            elif case2(value_e.BashArray):
-                array_val = cast(value.BashArray, val)
-                strs = []  # type: List[str]
-                for s in array_val.strs:
-                    if s is not None:
-                        strs.append(replacer.Replace(s, op))
-                val = value.BashArray(strs)
-
-            elif case2(value_e.BashAssoc):
-                assoc_val = cast(value.BashAssoc, val)
-                strs = []
-                for s in assoc_val.d.values():
-                    strs.append(replacer.Replace(s, op))
+            elif case2(value_e.BashArray, value_e.BashAssoc):
+                if val.tag() == value_e.BashArray:
+                    array_val = cast(value.BashArray, val)
+                    values = bash_impl.BashArray_GetValues(array_val)
+                elif val.tag() == value_e.BashAssoc:
+                    assoc_val = cast(value.BashAssoc, val)
+                    values = bash_impl.BashAssoc_GetValues(assoc_val)
+                else:
+                    raise AssertionError()
+                strs = [replacer.Replace(s, op) for s in values]
                 val = value.BashArray(strs)
 
             else:

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -375,12 +375,13 @@ def _PerformSlice(
                 e_die("Array slice can't have negative length: %d" % length,
                       loc.WordPart(part))
 
+            orig = bash_impl.BashArray_GetValues(val)
+
             # Quirk: "begin" for positional arguments ($@ and $*) counts $0.
             if arg0_val is not None:
-                orig = [arg0_val.s]
-                orig.extend(val.strs)
-            else:
-                orig = val.strs
+                new_list = [arg0_val.s]
+                new_list.extend(orig)
+                orig = new_list
 
             n = len(orig)
             if begin < 0:


### PR DESCRIPTION
This PR includes a set of refactoring changes for `${a[@]...}` for BashArray/BashAssoc. See respective commits.