### PR TITLE
[osh] Implement SparseArray `${a[@]:offset:count}`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -22,6 +22,18 @@ def BigInt_Less(a, b):
     return mops.Greater(b, a)
 
 
+def BigInt_GreaterEq(a, b):
+    # type: (mops.BigInt, mops.BigInt) -> bool
+
+    return not mops.Greater(b, a)
+
+
+def BigInt_LessEq(a, b):
+    # type: (mops.BigInt, mops.BigInt) -> bool
+
+    return not mops.Greater(a, b)
+
+
 #------------------------------------------------------------------------------
 # All BashArray operations depending on the internal
 # representation of SparseArray come here.

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -367,38 +367,91 @@ def _PerformSlice(
             substr = s[byte_begin:byte_end]
             result = value.Str(substr)  # type: value_t
 
-        elif case(value_e.BashArray):  # Slice array entries.
-            val = cast(value.BashArray, UP_val)
+        elif case(value_e.BashArray,
+                  value_e.SparseArray):  # Slice array entries.
             # NOTE: This error is ALWAYS fatal in bash.  It's inconsistent with
             # strings.
             if has_length and length < 0:
                 e_die("Array slice can't have negative length: %d" % length,
                       loc.WordPart(part))
 
-            orig = bash_impl.BashArray_GetValues(val)
+            offset = mops.IntWiden(begin)
+            if bash_impl.BigInt_Less(offset, mops.ZERO):
+                # ${@:-3} starts counts from the end
+                if val.tag() == value_e.BashArray:
+                    val = cast(value.BashArray, UP_val)
+                    array_length = mops.IntWiden(
+                        bash_impl.BashArray_Length(val))
+                elif val.tag() == value_e.SparseArray:
+                    val = cast(value.SparseArray, UP_val)
+                    array_length = bash_impl.SparseArray_Length(val)
+                else:
+                    raise AssertionError()
 
-            # Quirk: "begin" for positional arguments ($@ and $*) counts $0.
-            if arg0_val is not None:
-                new_list = [arg0_val.s]
-                new_list.extend(orig)
-                orig = new_list
+                # The array length counts $0 for $@ and $*
+                if arg0_val is not None:
+                    array_length = mops.Add(array_length, mops.ONE)
 
-            n = len(orig)
-            if begin < 0:
-                i = n + begin  # ${@:-3} starts counts from the end
+                offset = mops.Add(offset, array_length)
+
+            if bash_impl.BigInt_Less(offset, mops.ZERO):
+                strs = []  # type: List[str]
             else:
-                i = begin
-            strs = []  # type: List[str]
-            if i >= 0:
-                count = 0
-                while i < n:
-                    if has_length and count == length:  # length could be 0
-                        break
-                    s = orig[i]
-                    if s is not None:  # Unset elements don't count towards the length
-                        strs.append(s)
-                        count += 1
-                    i += 1
+                # Quirk: "begin" for positional arguments ($@ and $*) counts $0.
+                prepends_arg0 = False
+                if arg0_val is not None:
+                    if bash_impl.BigInt_Greater(offset, mops.ZERO):
+                        offset = mops.Sub(offset, mops.ONE)
+                    elif not has_length or length >= 1:
+                        prepends_arg0 = True
+                        length = length - 1
+
+                if has_length and length == 0:
+                    strs = []
+
+                elif val.tag() == value_e.BashArray:
+                    val = cast(value.BashArray, UP_val)
+                    orig = bash_impl.BashArray_GetValues(val)
+                    n = len(orig)
+
+                    strs = []
+                    i = mops.BigTruncate(offset)
+                    count = 0
+                    while i < n:
+                        if has_length and count == length:  # length could be 0
+                            break
+                        s = orig[i]
+                        if s is not None:  # Unset elements don't count towards the length
+                            strs.append(s)
+                            count += 1
+                        i += 1
+
+                elif val.tag() == value_e.SparseArray:
+                    val = cast(value.SparseArray, UP_val)
+
+                    # TODO: We may optimize this by finding the first index
+                    # using the binary search.  Furthermore, the sorting by
+                    # SparseArray_GetKeys can be replaced with the heap sort so
+                    # that we only extract the first LENGTH elements of the
+                    # indices greater or equal to OFFSET.
+                    i = 0
+                    for index in bash_impl.SparseArray_GetKeys(val):
+                        if bash_impl.BigInt_GreaterEq(index, offset):
+                            break
+                        i = i + 1
+
+                    if has_length:
+                        strs = bash_impl.SparseArray_GetValues(val)[i:i+length]
+                    else:
+                        strs = bash_impl.SparseArray_GetValues(val)[i:]
+
+                else:
+                    raise AssertionError()
+
+                if prepends_arg0:
+                    new_list = [arg0_val.s]
+                    new_list.extend(strs)
+                    strs = new_list
 
             result = value.BashArray(strs)
 

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -866,3 +866,122 @@ argv.py @a
 
 ## N-I bash/zsh/mksh/ash STDOUT:
 ## END
+
+
+#### SparseArray: ${a[@]:offset:length}
+case $SH in zsh|mksh|ash) exit ;; esac
+
+a=(v{0..9})
+unset -v 'a[2]' 'a[3]' 'a[4]' 'a[7]'
+case $SH in osh) eval 'var a = _a2sp(a)' ;; esac
+
+echo '==== ${a[@]:offset} ===='
+echo "[${a[@]:0}][${a[*]:0}]"
+echo "[${a[@]:2}][${a[*]:2}]"
+echo "[${a[@]:3}][${a[*]:3}]"
+echo "[${a[@]:5}][${a[*]:5}]"
+echo "[${a[@]:9}][${a[*]:9}]"
+echo "[${a[@]:10}][${a[*]:10}]"
+echo "[${a[@]:11}][${a[*]:11}]"
+
+echo '==== ${a[@]:negative} ===='
+echo "[${a[@]: -1}][${a[*]: -1}]"
+echo "[${a[@]: -2}][${a[*]: -2}]"
+echo "[${a[@]: -5}][${a[*]: -5}]"
+echo "[${a[@]: -9}][${a[*]: -9}]"
+echo "[${a[@]: -10}][${a[*]: -10}]"
+echo "[${a[@]: -11}][${a[*]: -11}]"
+echo "[${a[@]: -21}][${a[*]: -21}]"
+
+echo '==== ${a[@]:offset:length} ===='
+echo "[${a[@]:0:0}][${a[*]:0:0}]"
+echo "[${a[@]:0:1}][${a[*]:0:1}]"
+echo "[${a[@]:0:3}][${a[*]:0:3}]"
+echo "[${a[@]:2:1}][${a[*]:2:1}]"
+echo "[${a[@]:2:4}][${a[*]:2:4}]"
+echo "[${a[@]:3:4}][${a[*]:3:4}]"
+echo "[${a[@]:5:4}][${a[*]:5:4}]"
+echo "[${a[@]:5:0}][${a[*]:5:0}]"
+echo "[${a[@]:9:1}][${a[*]:9:1}]"
+echo "[${a[@]:9:2}][${a[*]:9:2}]"
+echo "[${a[@]:10:1}][${a[*]:10:1}]"
+
+## STDOUT:
+==== ${a[@]:offset} ====
+[v0 v1 v5 v6 v8 v9][v0 v1 v5 v6 v8 v9]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[v9][v9]
+[][]
+[][]
+==== ${a[@]:negative} ====
+[v9][v9]
+[v8 v9][v8 v9]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[v1 v5 v6 v8 v9][v1 v5 v6 v8 v9]
+[v0 v1 v5 v6 v8 v9][v0 v1 v5 v6 v8 v9]
+[][]
+[][]
+==== ${a[@]:offset:length} ====
+[][]
+[v0][v0]
+[v0 v1 v5][v0 v1 v5]
+[v5][v5]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[v5 v6 v8 v9][v5 v6 v8 v9]
+[][]
+[v9][v9]
+[v9][v9]
+[][]
+## END
+
+## N-I zsh/mksh/ash STDOUT:
+## END
+
+
+#### ${@:offset:length}
+case $SH in zsh|mksh|ash) exit ;; esac
+
+set -- v{1..9}
+
+{
+  echo '==== ${@:offset:length} ===='
+  echo "[${*:0:3}][${*:0:3}]"
+  echo "[${*:1:3}][${*:1:3}]"
+  echo "[${*:3:3}][${*:3:3}]"
+  echo "[${*:5:10}][${*:5:10}]"
+
+  echo '==== ${@:negative} ===='
+  echo "[${*: -1}][${*: -1}]"
+  echo "[${*: -3}][${*: -3}]"
+  echo "[${*: -9}][${*: -9}]"
+  echo "[${*: -10}][${*: -10}]"
+  echo "[${*: -11}][${*: -11}]"
+  echo "[${*: -3:2}][${*: -3:2}]"
+  echo "[${*: -9:4}][${*: -9:4}]"
+  echo "[${*: -10:4}][${*: -10:4}]"
+  echo "[${*: -11:4}][${*: -11:4}]"
+} | sed "s:$SH:\$SH:g;s:${SH##*/}:\$SH:g"
+
+## STDOUT:
+==== ${@:offset:length} ====
+[$SH v1 v2][$SH v1 v2]
+[v1 v2 v3][v1 v2 v3]
+[v3 v4 v5][v3 v4 v5]
+[v5 v6 v7 v8 v9][v5 v6 v7 v8 v9]
+==== ${@:negative} ====
+[v9][v9]
+[v7 v8 v9][v7 v8 v9]
+[v1 v2 v3 v4 v5 v6 v7 v8 v9][v1 v2 v3 v4 v5 v6 v7 v8 v9]
+[$SH v1 v2 v3 v4 v5 v6 v7 v8 v9][$SH v1 v2 v3 v4 v5 v6 v7 v8 v9]
+[][]
+[v7 v8][v7 v8]
+[v1 v2 v3 v4][v1 v2 v3 v4]
+[$SH v1 v2 v3][$SH v1 v2 v3]
+[][]
+## END
+
+## N-I zsh/mksh/ash STDOUT:
+## END

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -1,3 +1,4 @@
+## oils_cpp_failures_allowed: 2
 
 #### recursive arith: one level
 a='b=123'
@@ -474,6 +475,33 @@ declare -a sp1=([0]=D [2]=C [6]=B [9]=A)
 ## END
 
 ## N-I bash/zsh/mksh/ash STDOUT:
+## END
+
+
+#### SparseArray: a[i]=v with BigInt
+case $SH in zsh|mksh|ash) exit ;; esac
+
+sp1[1]=x
+sp1[5]=y
+sp1[9]=z
+case ${SH##*/} in osh) eval 'var sp1 = _a2sp(sp1)' ;; esac
+
+echo "${#sp1[@]}"
+sp1[0x7FFFFFFFFFFFFFFF]=a
+echo "${#sp1[@]}"
+sp1[0x7FFFFFFFFFFFFFFE]=b
+echo "${#sp1[@]}"
+sp1[0x7FFFFFFFFFFFFFFD]=c
+echo "${#sp1[@]}"
+
+## STDOUT:
+3
+4
+5
+6
+## END
+
+## N-I zsh/mksh/ash STDOUT:
 ## END
 
 

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -1036,5 +1036,15 @@ echo "[${a[@]: -4}][${a[*]: -4}]"
 [z y x][z y x]
 ## END
 
+# Note: Bash behavior depends on the version and the environment.  In some
+# conditions, the index 0x7FFFFFFFFFFFFFFF hits an integer overflow bug.  Then
+# all slicing with a negative index results in empty lists:
+## BUG bash STDOUT:
+[][]
+[][]
+[][]
+[][]
+## END
+
 ## N-I zsh/mksh/ash STDOUT:
 ## END

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -873,7 +873,7 @@ case $SH in zsh|mksh|ash) exit ;; esac
 
 a=(v{0..9})
 unset -v 'a[2]' 'a[3]' 'a[4]' 'a[7]'
-case $SH in osh) eval 'var a = _a2sp(a)' ;; esac
+case ${SH##*/} in osh) eval 'var a = _a2sp(a)' ;; esac
 
 echo '==== ${a[@]:offset} ===='
 echo "[${a[@]:0}][${a[*]:0}]"
@@ -981,6 +981,31 @@ set -- v{1..9}
 [v1 v2 v3 v4][v1 v2 v3 v4]
 [$SH v1 v2 v3][$SH v1 v2 v3]
 [][]
+## END
+
+## N-I zsh/mksh/ash STDOUT:
+## END
+
+
+#### SparseArray: ${a[@]:BigInt}
+case $SH in zsh|mksh|ash) exit ;; esac
+
+a=(1 2 3)
+case ${SH##*/} in osh) eval 'var a = _a2sp(a)' ;; esac
+a[0x7FFFFFFFFFFFFFFF]=x
+a[0x7FFFFFFFFFFFFFFE]=y
+a[0x7FFFFFFFFFFFFFFD]=z
+
+echo "[${a[@]: -1}][${a[*]: -1}]"
+echo "[${a[@]: -2}][${a[*]: -2}]"
+echo "[${a[@]: -3}][${a[*]: -3}]"
+echo "[${a[@]: -4}][${a[*]: -4}]"
+
+## STDOUT:
+[x][x]
+[y x][y x]
+[z y x][z y x]
+[z y x][z y x]
 ## END
 
 ## N-I zsh/mksh/ash STDOUT:


### PR DESCRIPTION
This PR actually largely rewrites the handling of the BashArray slicing together.

The second commit adds the support for BigInt *offset* in the construct `${a[@]:offset:count}`.
