### PR TITLE
[osh refactor] Refactor BashArray/BashAssoc `${!arr[@]}`

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -44,6 +44,17 @@ def BashArray_Length(array_val):
     return len(array_val.strs)
 
 
+def BashArray_GetKeys(array_val):
+    # type: (value.BashArray) -> List[int]
+
+    indices = []  # type: List[int]
+    for i, s in enumerate(array_val.strs):
+        if s is not None:
+            indices.append(i)
+
+    return indices
+
+
 def BashArray_GetValues(array_val):
     # type: (value.BashArray) -> List[str]
 
@@ -242,6 +253,12 @@ def BashAssoc_AppendDict(assoc_val, d):
 
     for key in d:
         assoc_val.d[key] = d[key]
+
+
+def BashAssoc_GetKeys(assoc_val):
+    # type: (value.BashAssoc) -> List[str]
+
+    return assoc_val.d.keys()
 
 
 def BashAssoc_GetValues(assoc_val):

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -805,12 +805,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         with tagswitch(val) as case:
             if case(value_e.BashArray):
                 val = cast(value.BashArray, UP_val)
-                # translation issue: tuple indices not supported in list comprehensions
-                #indices = [str(i) for i, s in enumerate(val.strs) if s is not None]
-                indices = []  # type: List[str]
-                for i, s in enumerate(val.strs):
-                    if s is not None:
-                        indices.append(str(i))
+                indices = [str(i) for i in bash_impl.BashArray_GetKeys(val)]
                 return value.BashArray(indices)
 
             elif case(value_e.BashAssoc):
@@ -818,7 +813,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 assert val.d is not None  # for MyPy, so it's not Optional[]
 
                 # BUG: Keys aren't ordered according to insertion!
-                return value.BashArray(val.d.keys())
+                keys = bash_impl.BashAssoc_GetKeys(val)
+                return value.BashArray(keys)
 
             else:
                 raise error.TypeErr(val, 'Keys op expected Str', token)


### PR DESCRIPTION
This is probably the last PR for the BashArray/BashAssoc refactoring with `bash_impl` for **the OSH sector**. There are still places related to **YSH** and **serialization** (JSON, pretty printing, etc.), where implementation details of BashArray/BashAssoc are assumed.