### PR TITLE
[ysh] Implement SparseArray `@[sp]` and `@sp`

### DIFF
--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -847,3 +847,22 @@ sp[-19]: ''.
 ## END
 ## N-I bash/zsh/mksh/ash STDERR:
 ## END
+
+
+#### SparseArray (YSH): @[sp] and @sp
+case $SH in bash|zsh|mksh|ash) exit ;; esac
+
+a=({0..5})
+unset -v 'a[1]' 'a[2]' 'a[4]'
+var a = _a2sp(a)
+
+shopt -s parse_at
+argv.py @[a]
+argv.py @a
+## STDOUT:
+['0', '3', '5']
+['0', '3', '5']
+## END
+
+## N-I bash/zsh/mksh/ash STDOUT:
+## END

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -179,6 +179,10 @@ def ToShellArray(val, blame_loc, prefix=''):
             array_val = cast(value.BashArray, UP_val)
             strs = bash_impl.BashArray_GetValues(array_val)
 
+        elif case2(value_e.SparseArray):
+            sparse_val = cast(value.SparseArray, UP_val)
+            strs = bash_impl.SparseArray_GetValues(sparse_val)
+
         else:
             raise error.TypeErr(val, "%sexpected List" % prefix, blame_loc)
 


### PR DESCRIPTION
Note: `SparseArray_GetValues` does not preserve the unset elements, but we can use it here (`val_opts.ToShellArray`) because the `None` elements will be ignored in the callers anyway: The function `val_opts.ToShellArray` is used to generate a list of words by `expr_eval.ExprEvaluator.{EvalExprSub,SpliceValue}`. These functions are used by `word_eval.AbstractWordEvaluator.EvalWord*` through `word_eval.AbstractWordEvaluator._EvalWordPart`.  The resulting array is processed by `word_eval._MakeWordFrames`, where `None` elements are ignored.