### PR TITLE
[test/sh_spec] Support multiple possible results

### DIFF
--- a/test/sh_spec_test.py
+++ b/test/sh_spec_test.py
@@ -92,11 +92,11 @@ class ShSpecTest(unittest.TestCase):
         pprint.pprint(CASE1)
         print()
 
-        expected = {'status': '0', 'stdout': 'v=None\n', 'qualifier': 'OK'}
+        expected = {'OK': {'status': '0', 'stdout': 'v=None\n'}}
         self.assertEqual(expected, CASE1['bash'])
         self.assertEqual(expected, CASE1['dash'])
         self.assertEqual(expected, CASE1['mksh'])
-        self.assertEqual('2', CASE1['status'])
+        self.assertEqual('2', CASE1['DEFAULT']['PASS']['status'])
         self.assertEqual('Env binding in readonly/declare disallowed',
                          CASE1['desc'])
 
@@ -104,15 +104,9 @@ class ShSpecTest(unittest.TestCase):
         pprint.pprint(CASE2)
         print()
         print(CreateAssertions(CASE2, 'bash'))
-        self.assertEqual('one\ntwo\n', CASE2['stdout'])
-        self.assertEqual({
-            'qualifier': 'OK',
-            'stdout': 'dash1\ndash2\n'
-        }, CASE2['dash'])
-        self.assertEqual({
-            'qualifier': 'OK',
-            'stdout': 'mksh1\nmksh2\n'
-        }, CASE2['mksh'])
+        self.assertEqual('one\ntwo\n', CASE2['DEFAULT']['PASS']['stdout'])
+        self.assertEqual({'OK': {'stdout': 'dash1\ndash2\n'}}, CASE2['dash'])
+        self.assertEqual({'OK': {'stdout': 'mksh1\nmksh2\n'}}, CASE2['mksh'])
 
     def testCreateAssertions(self):
         print(CreateAssertions(self.CASE1, 'bash'))


### PR DESCRIPTION
7b95b2c6091cb0124e6969ffb95dfd106de55f5a This fixes the problem of environment-dependent confirmed results in https://github.com/oils-for-unix/oils/pull/2184#issuecomment-2530164337. The current `master` only allows the possible combination of result levels to be one of `PASS | FAIL`, `OK | FAIL`, `N-I | FAIL`, and `BUG | FAIL` for each shell for each test case. This PR allows an arbitrary combination of possible result levels for each shell and each test case. For example, in the https://github.com/oils-for-unix/oils/pull/2184#issuecomment-2530164337 case, when Bash produces the expected results, it shows `PASS`. When Bash produces the confirmed buggy behavior, it shows `BUG`. Otherwise, it shows `FAIL`.

4f2768e76accdc45bbb774752afa6b1c8667ad4e This additionally supports registering multiple possible values for each result level.

