### PR TITLE
[test/sh_spec] Fix error message for C++ failures

### DIFF
--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -1453,7 +1453,7 @@ def _SuccessOrFailure(test_name, stats):
     if oils_cpp_count != 0:
         if oils_cpp_count != allowed_cpp:
             errors.append('Got %d Oils C++ failures, but %d are allowed' %
-                          (oils_cpp_count, allowed))
+                          (oils_cpp_count, allowed_cpp))
         else:
             if allowed_cpp != 0:
                 log('%s: note: Got %d allowed Oils C++ failures', test_name,


### PR DESCRIPTION
This is a trivial fix. In the current master, the error message for the error count shows a different number for the allowed C++ failures.