### PR TITLE
[test/sh_spec] Handle duplicate/conflicting test spec definitions

### DIFF
--- a/spec/arith.test.sh
+++ b/spec/arith.test.sh
@@ -859,7 +859,7 @@ echo ---
 ---
 ## END
 
-## OK bash/dash/mksh/zsh STDOUT:
+## OK bash/dash/zsh STDOUT:
 10
 5
 -9223372036854775808

--- a/spec/assign-extended.test.sh
+++ b/spec/assign-extended.test.sh
@@ -698,7 +698,7 @@ None
 2
 3
 ## END
-## OK mksh status: 0
+## BUG mksh status: 0
 
 #### syntax error in array assignment
 a=x b[0+]=y c=z

--- a/spec/ble-features.test.sh
+++ b/spec/ble-features.test.sh
@@ -550,7 +550,7 @@ v=tempenv1 f4_unset global,tempenv1
 [global,tempenv1,tempenv2,tempenv3] v: (unset) (unset 4)
 ## END
 
-## OK zsh/ash/dash/mksh/yash STDOUT:
+## OK zsh/ash/dash/mksh STDOUT:
 # value-unset, mksh-unset, tempenv-value-unset?
 [global,tempenv1,tempenv2,tempenv3] v: tempenv3
 [global,tempenv1,tempenv2,tempenv3] v: (unset) (unset 1)

--- a/spec/brace-expansion.test.sh
+++ b/spec/brace-expansion.test.sh
@@ -366,7 +366,7 @@ echo -{e..a..2}-
 -{a..e..-2}-
 -{e..a..2}-
 ## END
-## BUG mksh/zsh status: 0
+## N-I mksh/zsh status: 0
 
 #### Mixed case char expansion is invalid
 case $SH in *zsh) echo BUG; exit ;; esac

--- a/spec/bugs.test.sh
+++ b/spec/bugs.test.sh
@@ -98,7 +98,8 @@ foo $x() {
 }
 
 ## status: 2
-## OK mksh/zsh status: 1
+## OK mksh status: 1
+# Note: zsh should return 1 or 2
 ## BUG zsh status: 0
 ## STDOUT:
 ## END

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -1041,7 +1041,7 @@ echo status=$?
 [     2019-]
 status=0
 ## END
-## N-I dash/mksh/zsh/ash STDOUT:
+## N-I mksh/zsh/ash STDOUT:
 [[status=1
 ## END
 ## N-I dash STDOUT:

--- a/spec/builtin-read.test.sh
+++ b/spec/builtin-read.test.sh
@@ -223,7 +223,7 @@ case $SH in (dash|ash|zsh) exit ;; esac
 echo abcxyz | { read -n 3; echo reply=$REPLY; }
 ## status: 0
 ## stdout: reply=abc
-## N-I dash/ash/zsh stdout-json: ""
+## N-I dash/ash stdout-json: ""
 
 # zsh appears to hang with -k
 ## N-I zsh stdout-json: ""
@@ -254,7 +254,6 @@ echo '  a b  \
 [  a b  \]
 [a b  \]
 ## END
-## N-I dash stdout:
 ## BUG mksh/zsh STDOUT:
 [a b]
 [a b]

--- a/spec/dparen.test.sh
+++ b/spec/dparen.test.sh
@@ -133,11 +133,11 @@ echo $x ${A['y']}
 ## STDOUT:
 42 0
 ## END
-## BUG mksh status: 0
+## N-I mksh status: 0
 ## N-I mksh STDOUT:
 0
 ## END
-## BUG zsh status: 0
+## N-I zsh status: 0
 ## N-I zsh STDOUT:
 42
 ## END

--- a/spec/loop.test.sh
+++ b/spec/loop.test.sh
@@ -283,7 +283,7 @@ echo --
 a
 --
 ## END
-## OK bash status: 0
+## BUG bash status: 0
 ## BUG dash/mksh/zsh STDOUT:
 a
 b

--- a/spec/parse-errors.test.sh
+++ b/spec/parse-errors.test.sh
@@ -104,7 +104,7 @@ echo done
 ## stdout-json: ""
 ## status: 2
 ## OK mksh status: 1
-## OK bash status: 0
+## BUG bash status: 0
 ## BUG bash stdout: done
 
 #### bad var name globally isn't parsed like an assignment

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -18,7 +18,7 @@ echo status=$?
 ## status: 2
 ## stdout-json: ""
 ## OK osh/zsh status: 1
-## OK bash status: 0
+## BUG bash status: 0
 ## BUG bash STDOUT:
 status=1
 ## END

--- a/spec/var-op-len.test.sh
+++ b/spec/var-op-len.test.sh
@@ -70,7 +70,7 @@ true  # exit 0
 9
 7
 ## END
-## BUG dash/mksh stderr-json: ""
+## N-I dash/mksh stderr-json: ""
 ## N-I dash/mksh STDOUT:
 0
 1

--- a/spec/var-op-slice.test.sh
+++ b/spec/var-op-slice.test.sh
@@ -388,9 +388,6 @@ argv.py ${@:0:}
 
 ## status: 0
 ## STDOUT:
-
-## status: 0
-## STDOUT:
 []
 []
 

--- a/spec/xtrace.test.sh
+++ b/spec/xtrace.test.sh
@@ -183,11 +183,6 @@ x=1 x=2; echo $x; readonly x=3
 + echo 2
 + readonly x=3
 ## END
-## OK dash STDERR:
-+ x=1 x=2
-+ echo 2
-+ readonly x=3
-## END
 ## OK bash STDERR:
 + x=1
 + x=2

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -201,19 +201,15 @@ def AddMetadataToCase(case, qualifier, shells, name, value, line_num):
             raise ParseError('Line %d: duplicate spec %r for %r' %
                              (line_num, name, shell))
 
-        # Merge qualifier
-        if 'qualifier' in case[shell]:
-            # If there are multiple requirements of different qualifiers,
-            # choose the worst qualifier.  For example, when requirements of
-            # "OK" and "N-I" are both satisified, the result should be "N-I".
-            result_new = QualifierToResult(qualifier)
-            result_old = QualifierToResult(case[shell]['qualifier'])
-            if result_new < result_old:
-                case[shell]['qualifier'] = qualifier
-        else:
-            case[shell]['qualifier'] = qualifier
+        # Check inconsistent qualifier
+        if 'qualifier' in case[shell] and qualifier != case[shell]['qualifier']:
+            raise ParseError(
+                'Line %d: inconsistent qualifier %r is specified for %r, '
+                'but %r was previously specified.  '
+                % (line_num, qualifier, shell, case[shell]['qualifier']))
 
         case[shell][name] = value
+        case[shell]['qualifier'] = qualifier
 
 
 # Format of a test script.

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -194,9 +194,12 @@ def AddMetadataToCase(case, qualifier, shells, name, value, line_num):
             case[shell] = {}
 
         # Check a duplicate specification
-        if name in case[shell]:
-            raise ParseError(
-                'Line %d: duplicate spec %r for %r' % (line_num, name, shell))
+        name_without_type = re.sub(r'-(json|repr)$', '', name)
+        if (name_without_type in case[shell] or
+                name_without_type + '-json' in case[shell] or
+                name_without_type + '-repr' in case[shell]):
+            raise ParseError('Line %d: duplicate spec %r for %r' %
+                             (line_num, name, shell))
 
         # Merge qualifier
         if 'qualifier' in case[shell]:

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -1284,6 +1284,9 @@ def ParseTestList(test_files):
             except RuntimeError as e:
                 log('ERROR in %r', test_file)
                 raise
+            except ParseError as e:
+                log('PARSE ERROR in %r', test_file)
+                raise
 
         tmp = os.path.basename(test_file)
         spec_name = tmp.split('.')[0]  # foo.test.sh -> foo


### PR DESCRIPTION
This PR picks a part of #2192 to add checks for inconsistent spec tests.

fa625e262

- Check duplicate test spec definitions. For example, when the `STDOUT` section is specified multiple times for a specific shell, we produce an error message.
- Properly handle multiple levels of failure (`OK`, `BUG`, `N-I`, etc.). In the current master, when both `BUG` and `OK` requirements are specified for a specific shell, and when the `OK` requirement is specified later, the result shown in the table becomes `OK`. In this commit, we change it to choose the worst failure level. For example, when the shell satisfies the `BUG` and `OK` requirements, we show `BUG` in the table.
- This commit also modifies existing inconsistent test spec definitions

08cd83827

- In the current master, the filename is not printed when the parse error happens, which makes it difficult to identify the error location in the spec tests. This commit outputs the filename on `ParseError`.

ab7a324d4

- This commit also checks duplicates of `stdout`, `stdout-json`, and `stdout-repr`, or similar ones for `stderr` and `status`.