### PR TITLE
[osh] Perform indirect expansion with `${!a[@]...}`

### DIFF
--- a/doc/ref/chap-word-lang.md
+++ b/doc/ref/chap-word-lang.md
@@ -175,6 +175,33 @@ Open stdin as a named file in `/dev/fd`:
 
 ## Var Ops
 
+There are three types of braced variable expansions:
+
+    ${!name*} or ${!name@}
+    ${!name[@]} or ${!name[*]}
+    ${ops var ops}
+
+`name` needs to be a valid identifier.  If the expansion matches the first
+form, the variable names starting with `name` are generated.  Otherwise, if the
+expansion matches the second form, the keys of the indexed or associative array
+named `name` are generated.  When the expansion does not much either the first
+or second forms, it is interpreted as the third form of the variable name
+surrounded by operators.
+
+
+### op-indirect
+
+The indirection operator `!` is a prefix operator, and it interprets the
+received string as a variable name `name`, an array element `name[key]`, or an
+arrat list `name[@]` / `name[*]` and reads its values.
+
+    $ a=1234
+    $ v=a
+    $ echo $v
+    a
+    $ echo ${!v}
+    1234
+
 ### op-test
 
 Shell has boolean operations within `${}`.  I use `:-` most frequently:

--- a/doc/ref/toc-osh.md
+++ b/doc/ref/toc-osh.md
@@ -142,7 +142,8 @@ X [Unsupported]   enable
                   arith-sub     $((1 + 2))
                   tilde-sub     ~/src
                   proc-sub      diff <(sort L.txt) <(sort R.txt)
-  [Var Ops]       op-test       ${x:-default}  
+  [Var Ops]       op-indirect   ${!x}
+                  op-test       ${x:-default}
                   op-strip      ${x%%suffix}  etc.
                   op-patsub     ${x//y/z}
                   op-index      ${a[i+1}

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -1,4 +1,5 @@
 ## compare_shells: bash-4.4
+## oils_failures_allowed: 1
 
 # Var refs are done with ${!a}
 #
@@ -78,8 +79,9 @@ A_nobrackets=0
 
 #### ${!a[@]-'default'} is illegal
 
-# bash disallows this when a is an array.  We make it an error because [@]
-# implies it's an array.
+# bash disallows this when a is an array.  We originally made it an error
+# because [@] implies it's an array, but we now changed to follow Bash when the
+# array has a single element.
 
 argv.py "${!a[@]-default}"
 echo status=$?
@@ -89,6 +91,8 @@ argv.py "${!a[@]-default}"
 echo status=$?
 ## status: 1
 ## STDOUT:
+['default']
+status=0
 ## END
 ## BUG bash status: 0
 ## BUG bash STDOUT:
@@ -506,4 +510,267 @@ fi
 42
 PWNED
 0
+## END
+
+#### ${!array_ref:-set} and ${!array_ref:=assign}
+
+ref='a[@]'
+a=('' '' '')
+
+echo "==== check ===="
+
+argv.py "${!ref:-set}"
+argv.py "${a[@]:-set}"
+
+echo "==== assign ===="
+
+argv.py "${!ref:=assign}"
+argv.py "${!ref}"
+a=('' '' '') # revert the state in case it is modified
+
+argv.py "${a[@]:=assign}"
+argv.py "${a[@]}"
+
+## STDOUT:
+==== check ====
+['', '', '']
+['', '', '']
+==== assign ====
+['', '', '']
+['', '', '']
+['', '', '']
+['', '', '']
+## END
+
+#### Array indirect expansion with suffix operators
+
+declare -A ref=(['dummy']=v1)
+function test-suffixes {
+  echo "==== $1 ===="
+  ref['dummy']=$1
+  argv.py "${!ref[@]:2}"
+  argv.py "${!ref[@]:1:2}"
+  argv.py "${!ref[@]:-empty}"
+  argv.py "${!ref[@]:+set}"
+  argv.py "${!ref[@]:=assign}"
+}
+
+v1=value
+test-suffixes v1
+echo "v1=$v1"
+
+v2=
+test-suffixes v2
+echo "v2=$v2"
+
+a1=()
+test-suffixes a1
+argv.py "${a1[@]}"
+
+a2=(element)
+test-suffixes 'a2[0]'
+argv.py "${a2[@]}"
+
+a3=(1 2 3)
+test-suffixes 'a3[@]'
+argv.py "${a3[@]}"
+
+## STDOUT:
+==== v1 ====
+['lue']
+['al']
+['value']
+['set']
+['value']
+v1=value
+==== v2 ====
+['']
+['']
+['empty']
+['']
+['assign']
+v2=assign
+==== a1 ====
+['']
+['']
+['empty']
+['']
+['assign']
+['assign']
+==== a2[0] ====
+['ement']
+['le']
+['element']
+['set']
+['element']
+['element']
+==== a3[@] ====
+['3']
+['2', '3']
+['1', '2', '3']
+['set']
+['1', '2', '3']
+['1', '2', '3']
+## END
+
+#### Array indirect expansion with replacements
+
+declare -A ref=(['dummy']=v1)
+function test-rep {
+  echo "==== $1 ===="
+  ref['dummy']=$1
+  argv.py "${!ref[@]#?}"
+  argv.py "${!ref[@]%?}"
+  argv.py "${!ref[@]//[a-f]}"
+  argv.py "${!ref[@]//[a-f]/x}"
+}
+
+v1=value
+test-rep v1
+
+v2=
+test-rep v2
+
+a1=()
+test-rep a1
+
+a2=(element)
+test-rep 'a2[0]'
+
+a3=(1 2 3)
+test-rep 'a3[@]'
+
+## STDOUT:
+==== v1 ====
+['alue']
+['valu']
+['vlu']
+['vxlux']
+==== v2 ====
+['']
+['']
+['']
+['']
+==== a1 ====
+['']
+['']
+['']
+['']
+==== a2[0] ====
+['lement']
+['elemen']
+['lmnt']
+['xlxmxnt']
+==== a3[@] ====
+['', '', '']
+['', '', '']
+['1', '2', '3']
+['1', '2', '3']
+## END
+
+## BUG bash STDOUT:
+==== v1 ====
+['alue']
+['valu']
+['vlu']
+['vxlux']
+==== v2 ====
+['']
+['']
+['']
+['']
+==== a1 ====
+['']
+['']
+['']
+['']
+==== a2[0] ====
+['lement']
+['elemen']
+['lmnt']
+['xlxmxnt']
+==== a3[@] ====
+[]
+[]
+['1', '2', '3']
+['1', '2', '3']
+## END
+
+#### Array indirect expansion with @? conversion
+
+declare -A ref=(['dummy']=v1)
+function test-op0 {
+  echo "==== $1 ===="
+  ref['dummy']=$1
+  argv.py "${!ref[@]@Q}"
+  argv.py "${!ref[@]@P}"
+  argv.py "${!ref[@]@a}"
+}
+
+v1=value
+test-op0 v1
+
+v2=
+test-op0 v2
+
+a1=()
+test-op0 a1
+
+a2=(element)
+test-op0 'a2[0]'
+
+a3=(1 2 3)
+test-op0 'a3[@]'
+
+## STDOUT:
+==== v1 ====
+['value']
+['value']
+['']
+==== v2 ====
+["''"]
+['']
+['']
+==== a1 ====
+['']
+['']
+['a']
+==== a2[0] ====
+['element']
+['element']
+['a']
+==== a3[@] ====
+['1', '2', '3']
+['1', '2', '3']
+['a', 'a', 'a']
+## END
+
+# Bash 4.4 has a bug in the section "==== a3[@] ====".  Bash 5 correctly
+# outputs the following:
+#
+# ["'1'", "'2'", "'3'"]
+# ['1', '2', '3']
+# ['a', 'a', 'a']
+
+## BUG bash STDOUT:
+==== v1 ====
+["'value'"]
+['value']
+['']
+==== v2 ====
+["''"]
+['']
+['']
+==== a1 ====
+['']
+['']
+['a']
+==== a2[0] ====
+["'element'"]
+['element']
+['a']
+==== a3[@] ====
+[]
+[]
+[]
 ## END

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -77,11 +77,13 @@ A_keys=0
 A_nobrackets=0
 ## END
 
-#### ${!a[@]-'default'} is illegal
+#### ${!a[@]-'default'} is legal but fails with more than one element
 
-# bash disallows this when a is an array.  We originally made it an error
-# because [@] implies it's an array, but we now changed to follow Bash when the
-# array has a single element.
+# bash allows this construct, but the indirection fails when the array has more
+# than one element because the variable name contains a space.  OSH originally
+# made it an error unconditionally because [@] implies it's an array, so the
+# behavior has been different from Bash when the array has a single element.
+# We now changed it to follow Bash even when the array has a single element.
 
 argv.py "${!a[@]-default}"
 echo status=$?


### PR DESCRIPTION
- **PR(a)** I wanted to submit a PR for SparseArray `${sp[@]...}`
  - **PR(b)** However, the behaviors of existing BashArray/BashAssoc `${a[@]@Q}` and `${a[@]@a}` are broken, and `${a[@]@P}` is not implemented. So I first need to fix the behaviors of BashArray/BashAssoc `${a[@]@?}`.
    - **PR(c)** However, before fixing the above behavior, BashArray/BashAssoc `${a@a}` and `${a[0]@a}` need to be fixed because it implements something different from Bash's.
      - **PR(d)** Then, I tried to fix the above. However, I realized that even another incomplete behavior conflicts. `${!a[@]...}` should perform the indirect expansion, though `osh` tries to generate the keys of `a`.

This PR is **PR(d)** in the above chain. In the current master, osh interprets e.g. `${!a[@]...}` in a completely different way compare to Bash.

```bash
$ bash -c 'a=(var); var=value; echo "${!a[@]:0}"'
value
$ bin/osh -c 'a=(var); var=value; echo "${!a[@]:0}"'
0
```

Bash considers `${!a[@]:0}` as `Slice(IndirectExpansion(a[@]))` while osh considers it as `Slice(Keys(a))`. It should be noted that Bash's `${!a[@]}` treated as `Keys(a)` is an exceptional case, and in all the other cases, `!a[@]` is treated as an indirect expansion.
