### PR TITLE
[osh] Follow the Bash change in `${!undef[@]-}`

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -883,7 +883,9 @@ class AbstractWordEvaluator(StringWordEvaluator):
         UP_val = val
         with tagswitch(val) as case:
             if case(value_e.Undef):
-                return value.Undef  # ${!undef} is just weird bash behavior
+                # bash-4.4 returned value.Undef here. bash-5.0 started to treat
+                # the variable name to be empty so that the indirection fails.
+                var_ref_str = ''
 
             elif case(value_e.Str):
                 val = cast(value.Str, UP_val)

--- a/spec/var-op-test.test.sh
+++ b/spec/var-op-test.test.sh
@@ -258,14 +258,14 @@ argv.py ${!hooksSlice+"${!hooksSlice}"}
 foo=42
 bar=43
 
-declare -a hookSlice=(foo bar spam eggs)
+declare -a hooksSlice=(foo bar spam eggs)
 
 argv.py ${!hooksSlice+"${!hooksSlice}"}
 
 ## STDOUT:
 []
 []
-[]
+['42']
 ## END
 
 ## OK dash/mksh/zsh STDOUT:

--- a/spec/var-op-test.test.sh
+++ b/spec/var-op-test.test.sh
@@ -249,6 +249,10 @@ case $SH in dash|mksh|zsh) exit ;; esac
 
 # https://oilshell.zulipchat.com/#narrow/stream/307442-nix/topic/Replacing.20bash.20with.20osh.20in.20Nixpkgs.20stdenv
 
+(argv.py ${!hooksSlice+"${!hooksSlice}"})
+
+hooksSlice=x
+
 argv.py ${!hooksSlice+"${!hooksSlice}"}
 
 declare -a hookSlice=()
@@ -263,6 +267,15 @@ declare -a hooksSlice=(foo bar spam eggs)
 argv.py ${!hooksSlice+"${!hooksSlice}"}
 
 ## STDOUT:
+[]
+[]
+['42']
+## END
+
+# Bash 4.4 has a bug that ${!undef-} is successfully generate an empty word.
+
+## BUG bash STDOUT:
+[]
 []
 []
 ['42']

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -1,4 +1,4 @@
-## compare_shells: bash-4.4
+## compare_shells: bash
 ## oils_failures_allowed: 1
 
 # Var refs are done with ${!a}
@@ -59,7 +59,7 @@ echo a_nobrackets=$?
 echo ---
 declare -A A=([A]=a [B]=b)
 
-argv.py ${!A[@]}
+argv.py $(printf '%s\n' ${!A[@]} | sort)
 echo A_keys=$?
 
 argv.py "${!A}"  # missing [] is equivalent to ${!A[0]} ?
@@ -390,10 +390,13 @@ PWD=1
 ref='a[~+]'
 echo ${!ref}
 ## status: 1
-## BUG bash status: 0
-## BUG bash STDOUT:
-y
-## END
+
+# Bash 4.4 had a bug, which was fixed in Bash 5.0.
+#
+# ## BUG bash status: 0
+# ## BUG bash STDOUT:
+# y
+# ## END
 
 #### Indirect expansion TO fancy expansion features bash disallows
 
@@ -670,34 +673,6 @@ test-rep 'a3[@]'
 ['1', '2', '3']
 ## END
 
-## BUG bash STDOUT:
-==== v1 ====
-['alue']
-['valu']
-['vlu']
-['vxlux']
-==== v2 ====
-['']
-['']
-['']
-['']
-==== a1 ====
-['']
-['']
-['']
-['']
-==== a2[0] ====
-['lement']
-['elemen']
-['lmnt']
-['xlxmxnt']
-==== a3[@] ====
-[]
-[]
-['1', '2', '3']
-['1', '2', '3']
-## END
-
 #### Array indirect expansion with @? conversion
 
 declare -A ref=(['dummy']=v1)
@@ -747,12 +722,12 @@ test-op0 'a3[@]'
 ['a', 'a', 'a']
 ## END
 
-# Bash 4.4 has a bug in the section "==== a3[@] ====".  Bash 5 correctly
-# outputs the following:
+# Bash 4.4 had a bug in the section "==== a3[@] ====":
 #
-# ["'1'", "'2'", "'3'"]
-# ['1', '2', '3']
-# ['a', 'a', 'a']
+# ==== a3[@] ====
+# []
+# []
+# []
 
 ## BUG bash STDOUT:
 ==== v1 ====
@@ -772,7 +747,7 @@ test-op0 'a3[@]'
 ['element']
 ['a']
 ==== a3[@] ====
-[]
-[]
-[]
+["'1'", "'2'", "'3'"]
+['1', '2', '3']
+['a', 'a', 'a']
 ## END

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -30,7 +30,7 @@ x=foo
 ## END
 
 #### ${!undef:-}
-# bash gives empty string, but I feel like this could be an error
+# bash 4.4 gives empty string, but I feel like this could be an error
 echo undef=${!undef-'default'}
 echo undef=${!undef}
 
@@ -41,11 +41,19 @@ echo undef=${!undef}
 
 ## status: 1
 ## STDOUT:
-undef=default
-undef=
-NOUNSET
-undef=default
 ## END
+## OK bash STDOUT:
+NOUNSET
+## END
+
+# Bash 4.4 had been generating an empty string, but it was fixed in Bash 5.0.
+#
+# ## BUG bash STDOUT:
+# undef=default
+# undef=
+# NOUNSET
+# undef=default
+# ## END
 
 #### comparison to ${!array[@]} keys (similar SYNTAX)
 
@@ -62,10 +70,21 @@ declare -A A=([A]=a [B]=b)
 argv.py $(printf '%s\n' ${!A[@]} | sort)
 echo A_keys=$?
 
-argv.py "${!A}"  # missing [] is equivalent to ${!A[0]} ?
+(argv.py "${!A}")  # missing [] is equivalent to ${!A[0]} ?
 echo A_nobrackets=$?
 
 ## STDOUT:
+['0', '1']
+a_keys=0
+['']
+a_nobrackets=0
+---
+['A', 'B']
+A_keys=0
+A_nobrackets=1
+## END
+
+## BUG bash STDOUT:
 ['0', '1']
 a_keys=0
 ['']
@@ -85,23 +104,27 @@ A_nobrackets=0
 # behavior has been different from Bash when the array has a single element.
 # We now changed it to follow Bash even when the array has a single element.
 
-argv.py "${!a[@]-default}"
+(argv.py "${!a[@]-default}")
 echo status=$?
 
 a=(x y z)
-argv.py "${!a[@]-default}"
+(argv.py "${!a[@]-default}")
 echo status=$?
-## status: 1
+## status: 0
 ## STDOUT:
-['default']
-status=0
-## END
-## BUG bash status: 0
-## BUG bash STDOUT:
-['default']
-status=0
+status=1
 status=1
 ## END
+
+# Bash 4.4 had been generating an empty string for ${!undef[@]-}, but this was
+# fixed in Bash 5.0.
+#
+# ## BUG bash status: 0
+# ## BUG bash STDOUT:
+# ['default']
+# status=0
+# status=1
+# ## END
 
 
 #### var ref to $@ with @


### PR DESCRIPTION
This PR upgrades the spec tests in `var-ref` from bash-4 to bash-5 (dfc8fd8cc).

In addition, we change the behavior of `${!undef[@]-}` to match the behavior fixed in Bash 5 (7baa3a74d).

I wrote in https://github.com/oils-for-unix/oils/pull/2201#issuecomment-2563150818 that I would work on https://github.com/oils-for-unix/oils/pull/2201#discussion_r1897976186 and https://github.com/oils-for-unix/oils/pull/2201#discussion_r1897976947, but I decided to separate it from this PR because it seems to affect a wider range of behavior for `${!ref}` in general.