### PR TITLE
[ysh] Fix is-main when combined with use

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -1017,12 +1017,18 @@ class ctx_ModuleEval(object):
         assert len(mem.var_stack) == 1
         mem.var_stack[0] = self.new_frame
 
+        # Whenever we're use-ing, the 'is-main' builtin will return 1 (false)
+        self.to_restore = self.mem.is_main
+        self.mem.is_main = False
+
     def __enter__(self):
         # type: () -> None
         pass
 
     def __exit__(self, type, value_, traceback):
         # type: (Any, Any, Any) -> None
+
+        self.mem.is_main = self.to_restore
 
         assert len(self.mem.var_stack) == 1
         self.mem.var_stack[0] = self.saved_frame

--- a/spec/testdata/module2/main.ysh
+++ b/spec/testdata/module2/main.ysh
@@ -1,0 +1,9 @@
+shopt --set ysh:upgrade
+
+var __provide__ = []
+
+if is-main {
+  echo 'hi from main.ysh'
+} else {
+  echo 'main.ysh is not the main module'
+}

--- a/spec/ysh-builtin-module.test.sh
+++ b/spec/ysh-builtin-module.test.sh
@@ -38,6 +38,17 @@ stdin
 status=0
 ## END
 
+#### is-main with use/modules
+shopt --set ysh:upgrade
+
+use $REPO_ROOT/spec/testdata/module2/main.ysh
+$SH $REPO_ROOT/spec/testdata/module2/main.ysh
+
+## STDOUT:
+main.ysh is not the main module
+hi from main.ysh
+## END
+
 #### use builtin usage
 
 use


### PR DESCRIPTION
Previously, is-main would succeed in a module sourced via use