### PR TITLE
[osh] Return the placeholder type for `${a@a}` and `${a[0]@A}`

### DIFF
--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -59,7 +59,7 @@ module runtime
   coerced = Int | Float | Neither
 
   # evaluation state for BracedVarSub 
-  VarSubState = (bool join_array, bool is_type_query, Token array_ref)
+  VarSubState = (bool join_array, value holder_val, Token array_ref)
 
   # A Cell is a wrapper for a value.
   # TODO: add location for declaration for 'assigning const' error

--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -58,8 +58,9 @@ module runtime
 
   coerced = Int | Float | Neither
 
-  # evaluation state for BracedVarSub 
-  VarSubState = (bool join_array, value holder_val, Token array_ref)
+  # evaluation state for BracedVarSub.  See "doc/ref/chap-word-lang.md" for
+  # the description of h-value of a variable substitution.
+  VarSubState = (bool join_array, value h_value, Token array_ref)
 
   # A Cell is a wrapper for a value.
   # TODO: add location for declaration for 'assigning const' error

--- a/doc/ref/chap-word-lang.md
+++ b/doc/ref/chap-word-lang.md
@@ -297,3 +297,30 @@ string:
     $ unset -v x
     $ echo "value = $x, quoted = ${x@Q}."
     value = , quoted = .
+
+---
+
+`${x@a}` returns the set of characters that represent the attributes of the
+variable in which each resulting string is stored.
+
+- `a`: The value of `$x` would be obtained from an indexed array element.
+- `A`: The value of `$x` would be obtained from an associative array element.
+- `r`: The value of `$x` would be obtained from a readonly container.
+- `x`: The value of `$x` would be obtained from a container with the export attribute.
+- `n`: `x` is a name reference (OSH extension)
+
+It should be noted that `${x@a}` does not return the attributes of the obtained
+value.  For example, `${a[0]@a}` returns `a` because the string `${a[0]}` would
+be obtained from an array although the resulting value of `${a[0]}` is a scalar
+string.
+
+    $ echo ${a[0]@a}
+    a
+
+When `$x` would result in a word list (such as `${a[@]}` and `${!ref}` with
+`ref="a[@]"`), `${x@a}` returns a word list containing the attributes for each
+word.
+
+    $ a=(1 2 3)
+    $ echo "${a[@]@a}"
+    a a a

--- a/doc/ref/chap-word-lang.md
+++ b/doc/ref/chap-word-lang.md
@@ -300,34 +300,89 @@ string:
 
 ---
 
-`${x@a}` returns the set of characters that represent the attributes of
-*h-value* of the expansion `$x`.
+`${x@a}` returns characters that represent the attributes of the `${x}`, or
+more precisely, the *h-value* of `${x}`.
 
-Here, *h-value* is the variable (or the object that the variable directly
-points) from which the result of `$x` would originally come.  This is different
-from the *r-value* of the expansion `$x`, namely the result of the expansion
-`$x`.
+Definitions:
 
-The characters representing attributes are listed below:
+- *h-value* is the variable (or the object that the variable directly points)
+  from which the result of `${x}` would originally come.
+- *r-value* is the expansion of `${x}`
 
-- `a`: The value of `$x` would be obtained from an indexed array element.
-- `A`: The value of `$x` would be obtained from an associative array element.
-- `r`: The value of `$x` would be obtained from a readonly container.
-- `x`: The value of `$x` would be obtained from a container with the export attribute.
-- `n`: `x` is a name reference (OSH extension)
+For example, with `arr=(1 2 3)`:
 
-It should be noted that `${x@a}` does not return the attributes of the
-*r-value* of the expansion `$x`.  For example, although the *r-value* of
-`${arr[0]}` is arr scalar string, `${arr[0]@a}` returns `a` because the
-*h-value* is array `arr`, which stores the element `arr[0]`.
+<style>
+table { 
+  width: 100%;
+  margin-left: 2em;  /* matches p text in manual.css */
+}
+thead {
+  text-align: left;
+}
+</style>
 
-    $ echo ${arr[0]@a}
-    a
+<table>
 
-When `$x` would result in a word list (such as `${arr[@]}` and `${!ref}` with
-`ref="arr[@]"`), `${x@a}` returns a word list containing the attributes of the
-*h-value* of each word.
+- thead
+  - Reference
+  - Expression
+  - H-value
+  - R-value
+  - Flags returned
+- tr
+  - <!-- empty -->
+  - `${arr[0]@a}` or <br/> `${arr@a}`
+  - array<br/> `(1 2 3)`
+  - string<br/> `1`
+  - `a`
+- tr
+  - <!-- empty -->
+  - `${arr[@]@a}`
+  - array<br/> `(1 2 3)`
+  - array<br/> `(1 2 3)`
+  - `a a a`
+- tr
+  - `ref=arr` or `ref=arr[0]`
+  - `${!ref@a}`
+  - array<br/> `(1 2 3)`
+  - string<br/> `1`
+  - `a`
+  - <!-- empty -->
+- tr
+  - `ref=arr[@]`
+  - `${!ref@a}`
+  - array<br/> `(1 2 3)`
+  - array<br/> `(1 2 3)`
+  - `a a a`
 
-    $ arr=(1 2 3)
-    $ echo "${arr[@]@a}"
-    a a a
+</table>
+
+When `${x}` would result in a word list, `${x@a}` returns a word list
+containing the attributes of the *h-value* of each word.
+
+---
+
+These characters may be returned:
+
+<table>
+
+- thead
+  - Character
+  - Where `${x}` would be obtained
+- tr
+  - `a`
+  - indexed array
+- tr
+  - `A`
+  - associative array
+- tr
+  - `r`
+  - readonly container
+- tr
+  - `x`
+  - exported variable
+- tr
+  - `n`
+  - name reference (OSH extension)
+
+</table>

--- a/doc/ref/chap-word-lang.md
+++ b/doc/ref/chap-word-lang.md
@@ -307,7 +307,7 @@ Definitions:
 
 - *h-value* is the variable (or the object that the variable directly points)
   from which the result of `${x}` would originally come.
-- *r-value* is the expansion of `${x}`
+- *r-value* is the value of the expansion of `${x}`
 
 For example, with `arr=(1 2 3)`:
 

--- a/doc/ref/chap-word-lang.md
+++ b/doc/ref/chap-word-lang.md
@@ -300,8 +300,15 @@ string:
 
 ---
 
-`${x@a}` returns the set of characters that represent the attributes of the
-variable in which each resulting string is stored.
+`${x@a}` returns the set of characters that represent the attributes of
+*h-value* of the expansion `$x`.
+
+Here, *h-value* is the variable (or the object that the variable directly
+points) from which the result of `$x` would originally come.  This is different
+from the *r-value* of the expansion `$x`, namely the result of the expansion
+`$x`.
+
+The characters representing attributes are listed below:
 
 - `a`: The value of `$x` would be obtained from an indexed array element.
 - `A`: The value of `$x` would be obtained from an associative array element.
@@ -309,18 +316,18 @@ variable in which each resulting string is stored.
 - `x`: The value of `$x` would be obtained from a container with the export attribute.
 - `n`: `x` is a name reference (OSH extension)
 
-It should be noted that `${x@a}` does not return the attributes of the obtained
-value.  For example, `${a[0]@a}` returns `a` because the string `${a[0]}` would
-be obtained from an array although the resulting value of `${a[0]}` is a scalar
-string.
+It should be noted that `${x@a}` does not return the attributes of the
+*r-value* of the expansion `$x`.  For example, although the *r-value* of
+`${arr[0]}` is arr scalar string, `${arr[0]@a}` returns `a` because the
+*h-value* is array `arr`, which stores the element `arr[0]`.
 
-    $ echo ${a[0]@a}
+    $ echo ${arr[0]@a}
     a
 
-When `$x` would result in a word list (such as `${a[@]}` and `${!ref}` with
-`ref="a[@]"`), `${x@a}` returns a word list containing the attributes for each
-word.
+When `$x` would result in a word list (such as `${arr[@]}` and `${!ref}` with
+`ref="arr[@]"`), `${x@a}` returns a word list containing the attributes of the
+*h-value* of each word.
 
-    $ a=(1 2 3)
-    $ echo "${a[@]@a}"
+    $ arr=(1 2 3)
+    $ echo "${arr[@]@a}"
     a a a

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1104,7 +1104,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
             # We're ONLY simluating -a and -A, not -r -x -n for now.  See
             # spec/ble-idioms.test.sh.
             chars = []  # type: List[str]
-            with tagswitch(val) as case:
+            with tagswitch(vsub_state.holder_val) as case:
                 if case(value_e.BashArray):
                     chars.append('a')
                 elif case(value_e.BashAssoc):
@@ -1323,8 +1323,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         else:  # no bracket op
             var_name = vtest_place.name
             if (var_name is not None and
-                    val.tag() in (value_e.BashArray, value_e.BashAssoc) and
-                    not vsub_state.is_type_query):
+                    val.tag() in (value_e.BashArray, value_e.BashAssoc)):
                 if ShouldArrayDecay(var_name, self.exec_opts,
                                     not (part.prefix_op or part.suffix_op)):
                     # for ${BASH_SOURCE}, etc.
@@ -1353,6 +1352,9 @@ class AbstractWordEvaluator(StringWordEvaluator):
         else:
             # $* decays
             val = self._EvalSpecialVar(part.name_tok.id, quoted, vsub_state)
+
+        # update the holder of the current value
+        vsub_state.holder_val = val
 
         # We don't need var_index because it's only for L-Values of test ops?
         if self.exec_opts.eval_unsafe_arith():
@@ -1446,15 +1448,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         suffix_op_ = part.suffix_op
         if suffix_op_:
             UP_op = suffix_op_
-            with tagswitch(suffix_op_) as case:
-                if case(suffix_op_e.Nullary):
-                    suffix_op_ = cast(Token, UP_op)
-
-                    # Type query ${array@a} is a STRING, not an array
-                    # NOTE: ${array@Q} is ${array[0]@Q} in bash, which is different than
-                    # ${array[@]@Q}
-                    if suffix_op_.id == Id.VOp0_a:
-                        vsub_state.is_type_query = True
+        vsub_state.holder_val = val
 
         # 2. Bracket Op
         val = self._EvalBracketOp(val, part, quoted, vsub_state, vtest_place)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1104,7 +1104,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
             # We're ONLY simluating -a and -A, not -r -x -n for now.  See
             # spec/ble-idioms.test.sh.
             chars = []  # type: List[str]
-            with tagswitch(vsub_state.holder_val) as case:
+            with tagswitch(vsub_state.h_value) as case:
                 if case(value_e.BashArray):
                     chars.append('a')
                 elif case(value_e.BashAssoc):
@@ -1353,8 +1353,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
             # $* decays
             val = self._EvalSpecialVar(part.name_tok.id, quoted, vsub_state)
 
-        # update the holder of the current value
-        vsub_state.holder_val = val
+        # update h-value (i.e., the holder of the current value)
+        vsub_state.h_value = val
 
         # We don't need var_index because it's only for L-Values of test ops?
         if self.exec_opts.eval_unsafe_arith():
@@ -1448,7 +1448,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         suffix_op_ = part.suffix_op
         if suffix_op_:
             UP_op = suffix_op_
-        vsub_state.holder_val = val
+        vsub_state.h_value = val
 
         # 2. Bracket Op
         val = self._EvalBracketOp(val, part, quoted, vsub_state, vtest_place)

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -428,3 +428,37 @@ stat: 1
 stat: 1
 stat: 1
 ## END
+
+
+#### ${a[0]@a} and ${a@a}
+
+a=(1 2 3)
+echo "attr = '${a[0]@a}'"
+echo "attr = '${a@a}'"
+
+## STDOUT:
+attr = 'a'
+attr = 'a'
+## END
+
+
+#### ${!r@a} with r='a[0]' (attribute for indirect expansion of an array element)
+
+a=(1 2 3)
+r='a'
+echo ${!r@a}
+r='a[0]'
+echo ${!r@a}
+
+declare -A d=([0]=foo [1]=bar)
+r='d'
+echo ${!r@a}
+r='d[0]'
+echo ${!r@a}
+
+## STDOUT:
+a
+a
+A
+A
+## END

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -377,14 +377,24 @@ fail
 #### ${!A@a} and ${!A[@]@a}
 declare -A A=(["x"]=y)
 echo x=${!A[@]@a}
-echo x=${!A@a}
+echo invalid=${!A@a}
 
 # OSH prints 'a' for indexed array because the AssocArray with ! turns into
 # it.  Disallowing it would be the other reasonable behavior.
 
+## status: 1
 ## STDOUT:
 x=
+## END
+
+# Bash succeeds with ${!A@a}, which references the variable named as $A (i.e.,
+# '').  This must be a Bash bug since the behavior is inconsistent with the
+# fact that ${!undef@a} and ${!empty@a} fail.
+
+## BUG bash status: 0
+## BUG bash STDOUT:
 x=
+invalid=
 ## END
 
 #### undef vs. empty string in var ops


### PR DESCRIPTION
This corresponds to "**PR(c)**" explained in #2201. I'll submit the changes for **PR(b)** after settling this change.

I noticed that the behavior for `${a[0]@a}` is different from Bash:

* In Bash, `a` and `A` are used to mark the nature of **a string placeholder** (i.e., either a *scalar variable* or an *array element*), so `${a[0]@a}` generates `a` and `A` for indexed and associative arrays, respectively.
* However, in osh, `a` and `A` are used to mark the type of **an obtained value** (e.g., an empty string for a scalar variables, and `a` or `A` for word lists originating from indexed and associative arrays), so `${a[0]@a}` generates a empty string because `a[0]` is not an entire array.

I think the existing code comments in the osh codebase imply that the difference is intentional. Nevertheless, I think the function of `@a` should be the same as Bash.  Maybe one wants to have a way to get the type of *the obtained value*, but I think that should be implemented as a distinct operator.
