### PR TITLE
[osh] Implement `${a[@]@P}` and make `${a[@]@a}` and `${a[@]@Q}` consistent with Bash

### DIFF
--- a/osh/prompt.py
+++ b/osh/prompt.py
@@ -242,22 +242,18 @@ class Evaluator(object):
 
         return ''.join(ret)
 
-    def EvalPrompt(self, UP_val):
-        # type: (value_t) -> str
+    def EvalPrompt(self, s):
+        # type: (str) -> str
         """Perform the two evaluations that bash does.
 
         Used by $PS1 and ${x@P}.
         """
-        if UP_val.tag() != value_e.Str:
-            return ''  # e.g. if the user does 'unset PS1'
-
-        val = cast(value.Str, UP_val)
 
         # Parse backslash escapes (cached)
-        tokens = self.tokens_cache.get(val.s)
+        tokens = self.tokens_cache.get(s)
         if tokens is None:
-            tokens = match.Ps1Tokens(val.s)
-            self.tokens_cache[val.s] = tokens
+            tokens = match.Ps1Tokens(s)
+            self.tokens_cache[s] = tokens
 
         # Replace values.
         ps1_str = self._ReplaceBackslashCodes(tokens)
@@ -304,7 +300,12 @@ class Evaluator(object):
         # Now try evaluating $PS1
         ps1_val = self.mem.env_config.GetVal('PS1')
         #log('ps1_val %s', ps1_val)
-        return self.EvalPrompt(ps1_val)
+        UP_ps1_val = ps1_val
+        if UP_ps1_val.tag() == value_e.Str:
+            ps1_val = cast(value.Str, UP_ps1_val)
+            return self.EvalPrompt(ps1_val.s)
+        else:
+            return ''  # e.g. if the user does 'unset PS1'
 
 
 PROMPT_COMMAND = 'PROMPT_COMMAND'

--- a/osh/prompt_test.py
+++ b/osh/prompt_test.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 import unittest
 
-from _devbuild.gen.value_asdl import value
 from core import state
 from core import test_lib
 from frontend import match
@@ -25,13 +24,12 @@ class PromptTest(unittest.TestCase):
 
     def testEvaluator(self):
         # Regression for caching bug!
-        self.assertEqual('foo', self.p.EvalPrompt(value.Str('foo')))
-        self.assertEqual('foo', self.p.EvalPrompt(value.Str('foo')))
+        self.assertEqual('foo', self.p.EvalPrompt('foo'))
+        self.assertEqual('foo', self.p.EvalPrompt('foo'))
 
     def testNoEscapes(self):
         for prompt_str in ["> ", "osh>", "[[]][[]][][]]][["]:
-            self.assertEqual(self.p.EvalPrompt(value.Str(prompt_str)),
-                             prompt_str)
+            self.assertEqual(self.p.EvalPrompt(prompt_str), prompt_str)
 
     def testValidEscapes(self):
         for prompt_str in [
@@ -39,7 +37,7 @@ class PromptTest(unittest.TestCase):
                 r"\[\] hi \[hi\] \[\] hello"
         ]:
             self.assertEqual(
-                self.p.EvalPrompt(value.Str(prompt_str)),
+                self.p.EvalPrompt(prompt_str),
                 prompt_str.replace(r"\[", "\x01").replace(r"\]", "\x02"))
 
     def testInvalidEscapes(self):

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1129,7 +1129,18 @@ class AbstractWordEvaluator(StringWordEvaluator):
                     if cell.nameref:
                         chars.append('n')
 
-            result = value.Str(''.join(chars))
+            count = 1
+            with tagswitch(val) as case:
+                if case(value_e.Undef):
+                    count = 0
+                elif case(value_e.BashArray):
+                    val = cast(value.BashArray, UP_val)
+                    count = bash_impl.BashArray_Count(val)
+                elif case(value_e.BashAssoc):
+                    val = cast(value.BashAssoc, UP_val)
+                    count = bash_impl.BashAssoc_Count(val)
+
+            result = value.BashArray([''.join(chars)] * count)
 
         else:
             e_die('Var op %r not implemented' % lexer.TokenVal(op), op)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1078,7 +1078,10 @@ class AbstractWordEvaluator(StringWordEvaluator):
                     self._ProcessUndef(val, vsub_token, vsub_state)
 
                     # For unset variables, we do not generate any quoted words.
-                    result = value.Str('')
+                    if vsub_state.array_ref is not None:
+                        result = value.BashArray([])
+                    else:
+                        result = value.Str('')
 
                 elif case(value_e.Str):
                     str_val = cast(value.Str, UP_val)
@@ -1100,7 +1103,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                         # TODO: should use fastfunc.ShellEncode
                         j8_lite.MaybeShellEncode(s) for s in values
                     ]
-                    result = value.Str(' '.join(tmp))
+                    result = value.BashArray(tmp)
                 else:
                     e_die("Can't use @Q on %s" % ui.ValType(val), op)
 

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1060,7 +1060,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                     result = value.Str('')
                 elif case(value_e.Str):
                     str_val = cast(value.Str, UP_val)
-                    prompt = self.prompt_ev.EvalPrompt(str_val)
+                    prompt = self.prompt_ev.EvalPrompt(str_val.s)
                     # readline gets rid of these, so we should too.
                     p = prompt.replace('\x01', '').replace('\x02', '')
                     result = value.Str(p)

--- a/spec/prompt.test.sh
+++ b/spec/prompt.test.sh
@@ -234,12 +234,6 @@ status=0
 x
 status=0
 ## END
-## OK osh STDOUT:
-status=1
-status=1
-x
-status=0
-## END
 
 #### default PS1
 #flags='--norc --noprofile'

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -472,3 +472,81 @@ a
 A
 A
 ## END
+
+
+#### Array expansion with nullary var ops
+
+declare -a a=({1..9})
+declare -A A=(['a']=hello ['b']=world ['c']=osh ['d']=ysh)
+
+echo "@Q"
+argv.py "${a[@]@Q}"
+argv.py "${a[*]@Q}"
+argv.py "${A[@]@Q}"
+argv.py "${A[*]@Q}"
+argv.py "${u[@]@Q}"
+argv.py "${u[*]@Q}"
+
+echo "@P"
+argv.py "${a[@]@P}"
+argv.py "${a[*]@P}"
+argv.py "${A[@]@P}"
+argv.py "${A[*]@P}"
+argv.py "${u[@]@P}"
+argv.py "${u[*]@P}"
+
+echo "@a"
+argv.py "${a[@]@a}"
+argv.py "${a[*]@a}"
+argv.py "${A[@]@a}"
+argv.py "${A[*]@a}"
+argv.py "${u[@]@a}"
+argv.py "${u[*]@a}"
+
+## STDOUT:
+@Q
+['1', '2', '3', '4', '5', '6', '7', '8', '9']
+['1 2 3 4 5 6 7 8 9']
+['hello', 'world', 'osh', 'ysh']
+['hello world osh ysh']
+[]
+['']
+@P
+['1', '2', '3', '4', '5', '6', '7', '8', '9']
+['1 2 3 4 5 6 7 8 9']
+['hello', 'world', 'osh', 'ysh']
+['hello world osh ysh']
+[]
+['']
+@a
+['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a']
+['a a a a a a a a a']
+['A', 'A', 'A', 'A']
+['A A A A']
+[]
+['']
+## END
+
+## OK bash STDOUT:
+@Q
+["'1'", "'2'", "'3'", "'4'", "'5'", "'6'", "'7'", "'8'", "'9'"]
+["'1' '2' '3' '4' '5' '6' '7' '8' '9'"]
+["'ysh'", "'osh'", "'world'", "'hello'"]
+["'ysh' 'osh' 'world' 'hello'"]
+[]
+['']
+@P
+['1', '2', '3', '4', '5', '6', '7', '8', '9']
+['1 2 3 4 5 6 7 8 9']
+['ysh', 'osh', 'world', 'hello']
+['ysh osh world hello']
+[]
+['']
+@a
+['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a']
+['a a a a a a a a a']
+['A', 'A', 'A', 'A']
+['A A A A']
+[]
+['']
+## END

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -303,7 +303,7 @@ status=0
 status=1
 a $'b\\nc'
 status=0
-a
+a a a
 status=0
 ## END
 

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -300,7 +300,8 @@ status=0
 status=0
 ## END
 ## OK osh STDOUT:
-status=1
+a b c
+status=0
 a $'b\\nc'
 status=0
 a a a
@@ -328,7 +329,8 @@ A - A
 status=0
 ## END
 ## OK osh STDOUT:
-status=1
+- y
+status=0
 - y
 status=0
 A - A

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -315,7 +315,7 @@ $SH -c 'declare -A A=(["x"]="y"); echo ${A@P} - ${A[@]@P}'
 echo status=$?
 
 # note: "y z" causes a bug!
-$SH -c 'declare -A A=(["x"]="y"); echo ${A@Q} - ${A[@]@Q}'
+$SH -c 'declare -A A=(["x"]="y"); echo ${A@Q} - ${A[@]@Q}' | sed 's/^- y$/- '\''y'\''/'
 echo status=$?
 
 $SH -c 'declare -A A=(["x"]=y); echo ${A@a} - ${A[@]@a}'
@@ -324,14 +324,6 @@ echo status=$?
 - y
 status=0
 - 'y'
-status=0
-A - A
-status=0
-## END
-## OK osh STDOUT:
-- y
-status=0
-- y
 status=0
 A - A
 status=0

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash
-## oils_failures_allowed: 7
+## oils_failures_allowed: 8
 
 #### Lower Case with , and ,,
 x='ABC DEF'
@@ -297,14 +297,6 @@ status=0
 'a' 'b\nc'
 status=0
 
-status=0
-## END
-## OK osh STDOUT:
-a b c
-status=0
-a $'b\\nc'
-status=0
-a a a
 status=0
 ## END
 

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -1,5 +1,4 @@
 ## compare_shells: bash
-## oils_failures_allowed: 1
 
 # Var refs are done with ${!a}
 #
@@ -744,7 +743,7 @@ test-op0 'a3[@]'
 # []
 # []
 
-## BUG bash STDOUT:
+## OK bash STDOUT:
 ==== v1 ====
 ["'value'"]
 ['value']


### PR DESCRIPTION
This corresponds to **PR(b)** explained in #2201.

### The behavior for `@a`

* In Bash, for the same reason as described in #2208, `${a[@]@a}` generates `a a ... a` and `A A ... A` for indexed and
  associative arrays, respectively.
* In osh, for the same reason as described in #2208, `${a[@]@a}` generates single words `a` and `A` for indexed and
  associative arrays, respectively, because osh returns the type of the entire array.

### Others

This PR also includes the modification to `@Q`. Also, `@P` was only supported for a scalar variable, but now this PR implements it for BashArray/BashAssoc. 03cf713b2 is a related refactoring commit.
