### PR TITLE
[core/completion] Support scalar `COMPREPLY` with `compgen -F`

### DIFF
--- a/core/completion.py
+++ b/core/completion.py
@@ -631,12 +631,16 @@ class ShellFuncAction(CompletionAction):
                              self.func.name)
                 return
 
+            elif case(value_e.Str):
+                val = cast(value.Str, UP_val)
+                strs = [val.s]
+
             elif case(value_e.BashArray):
                 val = cast(value.BashArray, UP_val)
                 strs = bash_impl.BashArray_GetValues(val)
 
             else:
-                print_stderr('osh error: COMPREPLY should be an array, got %s' %
+                print_stderr('osh error: COMPREPLY should be an array or a string, got %s' %
                              ui.ValType(val))
                 return
 

--- a/spec/builtin-completion.test.sh
+++ b/spec/builtin-completion.test.sh
@@ -625,3 +625,16 @@ argv.py "${words[@]}"
 
 ## N-I bash STDOUT:
 ## END
+
+
+#### compgen -F with scalar COMPREPLY
+
+_comp_cmd_test() {
+  unset -v COMPREPLY
+  COMPREPLY=hello
+}
+compgen -F _comp_cmd_test
+
+## STDOUT:
+hello
+## END


### PR DESCRIPTION
With the current `master` branch,

```bash
$ bash -c '_test() { unset -v COMPREPLY; COMPREPLY=hello; }; compgen -F _test 2>/dev/null'
hello
$ bin/osh -c '_test() { unset -v COMPREPLY; COMPREPLY=hello; }; compgen -F _test 2>/dev/null'
$
```

This also includes a refactoring commit da6a6c168f354aed621384fd2adb6766aaaed24b. After that, the main change is introduced in commit 87c4e626f77a159a2ea17b35ed050cf5be3bf2b9.