### PR TITLE
[builtin] Fix `compadjust` crashes with empty and sparse `COMP_ARGV`

### DIFF
--- a/builtin/completion_osh.py
+++ b/builtin/completion_osh.py
@@ -476,7 +476,8 @@ class CompAdjust(vm._Builtin):
         # argv adjusted according to 'break_chars'.
         adjusted_argv = []  # type: List[str]
         for a in comp_argv:
-            completion.AdjustArg(a, break_chars, adjusted_argv)
+            if a is not None:
+                completion.AdjustArg(a, break_chars, adjusted_argv)
 
         if 'words' in var_names:
             state.BuiltinSetArray(self.mem, 'words', adjusted_argv)

--- a/builtin/completion_osh.py
+++ b/builtin/completion_osh.py
@@ -482,7 +482,7 @@ class CompAdjust(vm._Builtin):
             state.BuiltinSetArray(self.mem, 'words', adjusted_argv)
 
         n = len(adjusted_argv)
-        cur = adjusted_argv[-1]
+        cur = '' if n < 1 else adjusted_argv[-1]
         prev = '' if n < 2 else adjusted_argv[-2]
 
         if arg.s:

--- a/spec/builtin-completion.test.sh
+++ b/spec/builtin-completion.test.sh
@@ -594,3 +594,18 @@ bar
 compgen=0
 complete=0
 ## END
+
+
+#### compadjust with empty COMP_ARGV
+case $SH in bash) exit ;; esac
+
+COMP_ARGV=()
+compadjust words
+argv.py "${words[@]}"
+
+## STDOUT:
+[]
+## END
+
+## N-I bash STDOUT:
+## END

--- a/spec/builtin-completion.test.sh
+++ b/spec/builtin-completion.test.sh
@@ -609,3 +609,19 @@ argv.py "${words[@]}"
 
 ## N-I bash STDOUT:
 ## END
+
+
+#### compadjust with sparse COMP_ARGV
+case $SH in bash) exit ;; esac
+
+COMP_ARGV=({0..9})
+unset -v 'COMP_ARGV['{1,3,4,6,7,8}']'
+compadjust words
+argv.py "${words[@]}"
+
+## STDOUT:
+['0', '2', '5', '9']
+## END
+
+## N-I bash STDOUT:
+## END


### PR DESCRIPTION
There are two crashes with `compadjust`.

----

With the current `master` branch,

```console
$ bin/osh -c 'COMP_ARGV=(); compadjust cur words'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 171, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 141, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2098, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1735, in _Dispatch
    status = self._ExecuteList(node.children)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1974, in _ExecuteList
    status = self._Execute(child)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1624, in _Dispatch
    status = self._DoSimple(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 906, in _DoSimple
    status = self._RunSimpleCommand(cmd_val, cmd_st, run_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 567, in _RunSimpleCommand
    run_flags)
  File "/home/murase/.mwg/git/oilshell/oil/core/executor.py", line 452, in RunSimpleCommand
    return self.RunBuiltin(builtin_id, cmd_val)
  File "/home/murase/.mwg/git/oilshell/oil/core/executor.py", line 313, in RunBuiltin
    return self.RunBuiltinProc(builtin_proc, cmd_val)
  File "/home/murase/.mwg/git/oilshell/oil/core/executor.py", line 323, in RunBuiltinProc
    status = builtin_proc.Run(cmd_val)
  File "/home/murase/.mwg/git/oilshell/oil/builtin/completion_osh.py", line 485, in Run
    cur = adjusted_argv[-1]
IndexError: list index out of range
```

Commit e0df3557b fixes this.

----

Even having that fixed, there is another crash:

```console
$ bin/osh -c 'COMP_ARGV=(); COMP_ARGV[1]=hello; compadjust cur prev cword words'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 171, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 141, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2098, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1735, in _Dispatch
    status = self._ExecuteList(node.children)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1974, in _ExecuteList
    status = self._Execute(child)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1624, in _Dispatch
    status = self._DoSimple(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 906, in _DoSimple
    status = self._RunSimpleCommand(cmd_val, cmd_st, run_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 567, in _RunSimpleCommand
    run_flags)
  File "/home/murase/.mwg/git/oilshell/oil/core/executor.py", line 452, in RunSimpleCommand
    return self.RunBuiltin(builtin_id, cmd_val)
  File "/home/murase/.mwg/git/oilshell/oil/core/executor.py", line 313, in RunBuiltin
    return self.RunBuiltinProc(builtin_proc, cmd_val)
  File "/home/murase/.mwg/git/oilshell/oil/core/executor.py", line 323, in RunBuiltinProc
    status = builtin_proc.Run(cmd_val)
  File "/home/murase/.mwg/git/oilshell/oil/builtin/completion_osh.py", line 479, in Run
    completion.AdjustArg(a, break_chars, adjusted_argv)
  File "/home/murase/.mwg/git/oilshell/oil/core/completion.py", line 139, in AdjustArg
    for i, c in enumerate(arg):
TypeError: 'NoneType' object is not iterable
```

Commit b6f85b5a3 fixes it.
