### PR TITLE
[spec/var-op-bash] Split #24 into respective tests for `@Q`, `@P`, and `@a`

### DIFF
--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -460,12 +460,10 @@ A
 ## END
 
 
-#### Array expansion with nullary var ops
-
+#### Array expansion with nullary var op @Q
 declare -a a=({1..9})
 declare -A A=(['a']=hello ['b']=world ['c']=osh ['d']=ysh)
 
-echo "@Q"
 argv.py "${a[@]@Q}"
 argv.py "${a[*]@Q}"
 argv.py "${A[@]@Q}"
@@ -473,7 +471,29 @@ argv.py "${A[*]@Q}"
 argv.py "${u[@]@Q}"
 argv.py "${u[*]@Q}"
 
-echo "@P"
+## STDOUT:
+['1', '2', '3', '4', '5', '6', '7', '8', '9']
+['1 2 3 4 5 6 7 8 9']
+['hello', 'world', 'osh', 'ysh']
+['hello world osh ysh']
+[]
+['']
+## END
+
+## OK bash STDOUT:
+["'1'", "'2'", "'3'", "'4'", "'5'", "'6'", "'7'", "'8'", "'9'"]
+["'1' '2' '3' '4' '5' '6' '7' '8' '9'"]
+["'ysh'", "'osh'", "'world'", "'hello'"]
+["'ysh' 'osh' 'world' 'hello'"]
+[]
+['']
+## END
+
+
+#### Array expansion with nullary var op @P
+declare -a a=({1..9})
+declare -A A=(['a']=hello ['b']=world ['c']=osh ['d']=ysh)
+
 argv.py "${a[@]@P}"
 argv.py "${a[*]@P}"
 argv.py "${A[@]@P}"
@@ -481,7 +501,29 @@ argv.py "${A[*]@P}"
 argv.py "${u[@]@P}"
 argv.py "${u[*]@P}"
 
-echo "@a"
+## STDOUT:
+['1', '2', '3', '4', '5', '6', '7', '8', '9']
+['1 2 3 4 5 6 7 8 9']
+['hello', 'world', 'osh', 'ysh']
+['hello world osh ysh']
+[]
+['']
+## END
+
+## OK bash STDOUT:
+['1', '2', '3', '4', '5', '6', '7', '8', '9']
+['1 2 3 4 5 6 7 8 9']
+['ysh', 'osh', 'world', 'hello']
+['ysh osh world hello']
+[]
+['']
+## END
+
+
+#### Array expansion with nullary var op @a
+declare -a a=({1..9})
+declare -A A=(['a']=hello ['b']=world ['c']=osh ['d']=ysh)
+
 argv.py "${a[@]@a}"
 argv.py "${a[*]@a}"
 argv.py "${A[@]@a}"
@@ -490,45 +532,6 @@ argv.py "${u[@]@a}"
 argv.py "${u[*]@a}"
 
 ## STDOUT:
-@Q
-['1', '2', '3', '4', '5', '6', '7', '8', '9']
-['1 2 3 4 5 6 7 8 9']
-['hello', 'world', 'osh', 'ysh']
-['hello world osh ysh']
-[]
-['']
-@P
-['1', '2', '3', '4', '5', '6', '7', '8', '9']
-['1 2 3 4 5 6 7 8 9']
-['hello', 'world', 'osh', 'ysh']
-['hello world osh ysh']
-[]
-['']
-@a
-['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a']
-['a a a a a a a a a']
-['A', 'A', 'A', 'A']
-['A A A A']
-[]
-['']
-## END
-
-## OK bash STDOUT:
-@Q
-["'1'", "'2'", "'3'", "'4'", "'5'", "'6'", "'7'", "'8'", "'9'"]
-["'1' '2' '3' '4' '5' '6' '7' '8' '9'"]
-["'ysh'", "'osh'", "'world'", "'hello'"]
-["'ysh' 'osh' 'world' 'hello'"]
-[]
-['']
-@P
-['1', '2', '3', '4', '5', '6', '7', '8', '9']
-['1 2 3 4 5 6 7 8 9']
-['ysh', 'osh', 'world', 'hello']
-['ysh osh world hello']
-[]
-['']
-@a
 ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a']
 ['a a a a a a a a a']
 ['A', 'A', 'A', 'A']


### PR DESCRIPTION
https://github.com/oils-for-unix/oils/pull/2210#discussion_r1901061335

I split the test into three, but it seems non-trivial to normalize the results so that the expected STDOUT can be shared. It is because, to normalize the results (particularly for the hash ordering), one needs to assume the form of the results, which is actually the test target. In this PR, I just split the tests and reduced the OK sections for the tests with the common results. I think this is sufficient because it is now easy to compare these smaller OK sections with the corresponding PASS sections.
