### PR TITLE
[mycpp] Fix constructor with template arguments deleted in C++20

### DIFF
--- a/mycpp/mark_sweep_heap.h
+++ b/mycpp/mark_sweep_heap.h
@@ -193,7 +193,7 @@ class Pool {
   std::vector<Block*> blocks_;
   MarkSet mark_set_;
 
-  DISALLOW_COPY_AND_ASSIGN(Pool<CellsPerBlock COMMA CellSize>);
+  DISALLOW_COPY_AND_ASSIGN(Pool);
 };
 
 class MarkSweepHeap {


### PR DESCRIPTION
The constructor declaration/definition of the form `template<typename T> class C { C<T>(); }` is removed in C++20. This causes many compiler warnings in recent compilers. One can always declare it without template arguments (in any C++ versions): `template<typename T> class C { C(); }`.