### PR TITLE
[osh] Fix crashes with `s+=([0]=v)`, `a+=([0]=v)`, and `assoc+=(0)`

### DIFF
--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -208,7 +208,7 @@ def PlusEquals(old_val, val):
                 str_to_append = cast(value.Str, UP_val)
                 val = value.Str(old_val.s + str_to_append.s)
 
-            elif tag in (value_e.BashArray, value_e.SparseArray):
+            elif tag in (value_e.BashArray, value_e.SparseArray, value_e.BashAssoc):
                 e_die("Can't append array to string")
 
             else:
@@ -236,12 +236,18 @@ def PlusEquals(old_val, val):
                     bash_impl.SparseArray_AppendValues(sparse_lhs, strs)
                     val = sparse_lhs
 
+            elif tag == value_e.BashAssoc:
+                e_die("Can't append an associative array to an indexed array")
+
             else:
                 raise AssertionError()  # parsing should prevent this
 
         elif case(value_e.BashAssoc):
             if tag == value_e.Str:
                 e_die("Can't append string to associative arrays")
+
+            elif tag in (value_e.BashArray, value_e.SparseArray):
+                e_die("Can't append an assoxiative array to indexed arrays")
 
             elif tag == value_e.BashAssoc:
                 assoc_lhs = cast(value.BashAssoc, UP_old_val)

--- a/spec/append.test.sh
+++ b/spec/append.test.sh
@@ -301,3 +301,29 @@ echo "${e[@]}"
 ## N-I bash STDOUT:
 e x
 ## END
+
+
+#### Type mismatching of lhs+=rhs should not cause a crash
+case $SH in mksh|zsh) exit ;; esac
+s=
+a=()
+declare -A d=([lemon]=yellow)
+
+s+=(1)
+s+=([melon]=green)
+
+a+=lime
+a+=([1]=banana)
+
+d+=orange
+d+=(0)
+
+true
+
+## STDOUT:
+## END
+
+## OK osh status: 1
+
+## N-I mksh/zsh STDOUT:
+## END


### PR DESCRIPTION
In the current `master` branch,

```console
$ bin/osh -c 's= s+=([a]=b)'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 171, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 141, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2098, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1634, in _Dispatch
    status = self._DoShAssignment(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 976, in _DoShAssignment
    val = PlusEquals(old_val, rhs)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 215, in PlusEquals
    raise AssertionError()  # parsing should prevent this
AssertionError
$ bin/osh -c 'a=() a+=([a]=b)'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 171, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 141, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2098, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1634, in _Dispatch
    status = self._DoShAssignment(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 976, in _DoShAssignment
    val = PlusEquals(old_val, rhs)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 240, in PlusEquals
    raise AssertionError()  # parsing should prevent this
AssertionError
$ bin/osh -c 'd=([x]=y) d+=()'
Traceback (most recent call last):
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 171, in main
    return AppBundleMain(argv)
  File "/home/murase/.mwg/git/oilshell/oil/bin/oils_for_unix.py", line 141, in AppBundleMain
    return shell.Main('osh', arg_r, environ, login_shell, loader, readline)
  File "/home/murase/.mwg/git/oilshell/oil/core/shell.py", line 1213, in Main
    cmd_flags=cmd_eval.IsMainProgram)
  File "/home/murase/.mwg/git/oilshell/oil/core/main_loop.py", line 375, in Batch
    is_return, is_fatal = cmd_ev.ExecuteAndCatch(node, cmd_flags)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 2098, in ExecuteAndCatch
    status = self._Execute(node)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1897, in _Execute
    status = self._Dispatch(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 1634, in _Dispatch
    status = self._DoShAssignment(node, cmd_st)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 976, in _DoShAssignment
    val = PlusEquals(old_val, rhs)
  File "/home/murase/.mwg/git/oilshell/oil/osh/cmd_eval.py", line 254, in PlusEquals
    raise AssertionError()  # parsing should prevent this
AssertionError
```

These can be later extended to allow promoting string to arrays or to support the general initializer list, but at least it should not cause the tracebacks for `AssertionError`.

