### PR TITLE
[doc] Fix promptVal example

### DIFF
--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -820,8 +820,8 @@ An API the wraps the `$PS1` language.  For example, to simulate `PS1='\w\$ '`:
 
     func renderPrompt(io) {
       var parts = []
-      call parts->append(io.promptval('w'))  # pass 'w' for \w
-      call parts->append(io.promptval('$'))  # pass '$' for \$
+      call parts->append(io.promptVal('w'))  # pass 'w' for \w
+      call parts->append(io.promptVal('$'))  # pass '$' for \$
       call parts->append(' ')
       return (join(parts))
     }


### PR DESCRIPTION
was testing the docs to set myself a custom prompt as described in ~/.config/oils/yshrc and ran into:
```
<Runtime error: Attribute 'promptval' not found on Obj>
```