### PR TITLE
`sh_spec.py` check for range out of bounds

### DIFF
--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -647,6 +647,14 @@ def RunCases(cases, case_predicate, shells, env, out, opts):
 
     #pprint.pprint(cases)
 
+    if isinstance(case_predicate, spec_lib.RangePredicate) and (
+        case_predicate.begin > (len(cases) - 1)
+    ):
+        raise RuntimeError(
+            "valid case indexes are from 0 to %s. given range: %s-%s"
+            % ((len(cases) - 1), case_predicate.begin, case_predicate.end)
+        )
+
     sh_labels = [sh_label for sh_label, _ in shells]
 
     out.WriteHeader(sh_labels)


### PR DESCRIPTION
I ran into this little thing when I was running new test cases and was accidentally checked out to the wrong branch. It ran 0 cases and exited normally and I was confused.
