### PR TITLE
let users disable horizontal-scroll-mode

### DIFF
--- a/core/comp_ui_test.py
+++ b/core/comp_ui_test.py
@@ -7,6 +7,7 @@ import sys
 import unittest
 
 from core import comp_ui  # module under test
+from core import state
 from core import util
 from mycpp import iolib
 
@@ -118,10 +119,11 @@ class UiTest(unittest.TestCase):
         prompt_state = comp_ui.PromptState()
         debug_f = util.DebugFile(sys.stdout)
         signal_safe = iolib.InitSignalSafe()
+        mem = state.Mem()
 
         # terminal width
         d1 = comp_ui.NiceDisplay(80, comp_ui_state, prompt_state, debug_f,
-                                 line_input, signal_safe)
+                                 line_input, signal_safe, mem)
         d2 = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f)
 
         prompt_state.SetLastPrompt('$ ')

--- a/core/shell.py
+++ b/core/shell.py
@@ -1093,7 +1093,8 @@ def Main(
             if term_width != 0:
                 display = comp_ui.NiceDisplay(
                     term_width, comp_ui_state, prompt_state, debug_f, readline,
-                    signal_safe)  # type: comp_ui._IDisplay
+                    signal_safe, mem)  # type: comp_ui._IDisplay
+
             else:
                 display = comp_ui.MinimalDisplay(comp_ui_state, prompt_state,
                                                  debug_f)
@@ -1126,6 +1127,7 @@ def Main(
 
             assert line_reader is not None
             line_reader.Reset()  # After sourcing startup file, render $PS1
+            display.Reset()
 
             prompt_plugin = prompt.UserPlugin(mem, parse_ctx, cmd_ev, errfmt)
             try:

--- a/frontend/flag_def.py
+++ b/frontend/flag_def.py
@@ -272,7 +272,7 @@ MAIN_SPEC.LongFlag('--ast-format',
                    default='abbrev-text')
 
 # Defines completion style.
-MAIN_SPEC.LongFlag('--completion-display', ['minimal', 'nice'], default='nice')
+MAIN_SPEC.LongFlag('--completion-display', ['bash', 'minimal', 'nice'], default='nice')
 # TODO: Add option for YSH prompt style?  RHS prompt?
 
 MAIN_SPEC.LongFlag('--completion-demo')


### PR DESCRIPTION
This commit adds an environment variable for controlling readline's
horizontal-scroll-mode. You can now disable the scroll mode by setting
OILS_READLINE_HORIZONTAL_SCROLL_MODE=off.

This should help with #2081 