### PR TITLE
make minimal completion display more bash-like

### DIFF
--- a/core/comp_ui.py
+++ b/core/comp_ui.py
@@ -93,6 +93,10 @@ class _IDisplay(object):
         self.f = f
         self.debug_f = debug_f
 
+    def ReadlineInitCommands(self):
+        # type: () -> List[str]
+        return []
+
     def PrintCandidates(self, unused_subst, matches, unused_match_len):
         # type: (Optional[str], List[str], int) -> None
         try:
@@ -340,6 +344,10 @@ class NiceDisplay(_IDisplay):
         # hash of matches -> count.  Has exactly ONE entry at a time.
         self.dupes = {}  # type: Dict[int, int]
 
+    def ReadlineInitCommands(self):
+        # type: () -> List[str]
+        return ['set horizontal-scroll-mode on']
+
     def Reset(self):
         # type: () -> None
         """Call this in between commands."""
@@ -548,7 +556,8 @@ def InitReadline(
 
     readline.parse_and_bind('tab: complete')
 
-    readline.parse_and_bind('set horizontal-scroll-mode on')
+    for cmd in display.ReadlineInitCommands():
+        readline.parse_and_bind(cmd)
 
     # How does this map to C?
     # https://cnswww.cns.cwru.edu/php/chet/readline/readline.html#SEC45

--- a/core/comp_ui.py
+++ b/core/comp_ui.py
@@ -109,7 +109,7 @@ class _IDisplay(object):
         self.term_width = _GetTerminalWidth()
         self.signal_safe = signal_safe
 
-    def _GetTerminalWidth(self):
+    def _GetTermWidth(self):
         # type: () -> int
         if self.signal_safe.PollSigWinch():  # is our value dirty?
             self.term_width = _GetTerminalWidth()
@@ -192,7 +192,7 @@ class MinimalDisplay(_IDisplay):
         to_display = [m[display_pos:] for m in matches]
         lens = [len(m) for m in to_display]
         max_match_len = max(lens)
-        term_width = self._GetTerminalWidth()
+        term_width = self._GetTermWidth()
         _PrintPacked(to_display, max_match_len, term_width, self.num_lines_cap, self.f)
 
         self._RedrawPrompt()
@@ -380,7 +380,7 @@ class NiceDisplay(_IDisplay):
 
         # Go right, but not more than the terminal width.
         n = orig_len + last_prompt_len
-        n = n % self._GetTerminalWidth()
+        n = n % self._GetTermWidth()
         self.f.write('\x1b[%dC' % n)  # RIGHT
 
         if self.bold_line:
@@ -390,7 +390,7 @@ class NiceDisplay(_IDisplay):
 
     def _PrintCandidates(self, unused_subst, matches, unused_max_match_len):
         # type: (Optional[str], List[str], int) -> None
-        term_width = self._GetTerminalWidth()
+        term_width = self._GetTermWidth()
 
         # Variables set by the completion generator.  They should always exist,
         # because we can't get "matches" without calling that function.
@@ -470,7 +470,7 @@ class NiceDisplay(_IDisplay):
             #log('PrintOptional %r', msg, file=DEBUG_F)
 
             # Truncate to terminal width
-            max_len = self._GetTerminalWidth() - 2
+            max_len = self._GetTermWidth() - 2
             if len(msg) > max_len:
                 msg = msg[:max_len - 5] + ' ... '
 
@@ -491,7 +491,7 @@ class NiceDisplay(_IDisplay):
 
     def ShowPromptOnRight(self, rendered):
         # type: (str) -> None
-        n = self._GetTerminalWidth() - 2 - len(rendered)
+        n = self._GetTermWidth() - 2 - len(rendered)
         spaces = ' ' * n
 
         # We avoid drawing problems if we print it on its own line:

--- a/core/comp_ui_test.py
+++ b/core/comp_ui_test.py
@@ -122,7 +122,7 @@ class UiTest(unittest.TestCase):
         # terminal width
         d1 = comp_ui.NiceDisplay(80, comp_ui_state, prompt_state, debug_f,
                                  line_input, signal_safe)
-        d2 = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f)
+        d2 = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f, 80, signal_safe)
 
         prompt_state.SetLastPrompt('$ ')
 

--- a/core/comp_ui_test.py
+++ b/core/comp_ui_test.py
@@ -120,9 +120,9 @@ class UiTest(unittest.TestCase):
         signal_safe = iolib.InitSignalSafe()
 
         # terminal width
-        d1 = comp_ui.NiceDisplay(80, comp_ui_state, prompt_state, debug_f,
+        d1 = comp_ui.NiceDisplay(comp_ui_state, prompt_state, debug_f,
                                  line_input, signal_safe)
-        d2 = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f, 80, signal_safe)
+        d2 = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f, signal_safe)
 
         prompt_state.SetLastPrompt('$ ')
 

--- a/core/shell.py
+++ b/core/shell.py
@@ -101,8 +101,6 @@ if mylib.PYTHON:
     except ImportError:
         help_meta = None
 
-DEFAULT_TERM_WIDTH = 80
-
 
 def _InitDefaultCompletions(cmd_ev, complete_builtin, comp_lookup):
     # type: (cmd_eval.CommandEvaluator, completion_osh.Complete, completion.Lookup) -> None
@@ -1085,23 +1083,12 @@ def Main(
         mutable_opts.set_redefine_source()
 
         if readline:
-            term_width = 0
-            try:
-                term_width = libc.get_terminal_width()
-            except (IOError, OSError):  # stdin not a terminal
-                pass
-
-            if flag.completion_display == 'nice' and term_width != 0:
-                display = comp_ui.NiceDisplay(
-                    term_width, comp_ui_state, prompt_state, debug_f, readline,
-                    signal_safe)  # type: comp_ui._IDisplay
+            if flag.completion_display == 'nice':
+                display = comp_ui.NiceDisplay(comp_ui_state, prompt_state,
+                    debug_f, readline, signal_safe)  # type: comp_ui._IDisplay
             else:
-                if term_width == 0:
-                    term_width = DEFAULT_TERM_WIDTH
-
                 display = comp_ui.MinimalDisplay(comp_ui_state, prompt_state,
-                                                 debug_f, term_width,
-                                                 signal_safe)
+                                                 debug_f, signal_safe)
 
             comp_ui.InitReadline(readline, sh_files.HistoryFile(), root_comp,
                                  display, debug_f)
@@ -1111,8 +1098,7 @@ def Main(
 
         else:  # Without readline module
             display = comp_ui.MinimalDisplay(comp_ui_state, prompt_state,
-                                             debug_f, DEFAULT_TERM_WIDTH,
-                                             signal_safe)
+                                             debug_f, signal_safe)
 
         process.InitInteractiveShell(signal_safe)  # Set signal handlers
 

--- a/frontend/flag_def.py
+++ b/frontend/flag_def.py
@@ -272,7 +272,7 @@ MAIN_SPEC.LongFlag('--ast-format',
                    default='abbrev-text')
 
 # Defines completion style.
-MAIN_SPEC.LongFlag('--completion-display', ['minimal', 'nice'], default='nice')
+MAIN_SPEC.LongFlag('--completion-display', ['minimal', 'nice'], default='minimal')
 # TODO: Add option for YSH prompt style?  RHS prompt?
 
 MAIN_SPEC.LongFlag('--completion-demo')


### PR DESCRIPTION
There are three commits here. One makes it so only the nice completion display sets `horizontal-scroll-mode`. This should help with #2081. The other changes the display style of the minimal completion display. Instead of only printing a subset of matches in a single column and saying that there are more, we now just print them all in the packed format. This behavior will be more similar to what bash users are familiar with and just generally more useful. The last change makes the minimal completion display the default. This should minimize friction for newcomers.