### PR TITLE
[osh] Fix unquoted `$*`, `${*}`, `${a[*]}`, etc. under empty IFS

### DIFF
--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -52,7 +52,7 @@ module runtime
 
     # "$@" or "${a[@]}" # never globbed or split (though other shells
     # split them)
-  | Array(List[str] strs)
+  | Array(List[str] strs, bool quoted)
     # only produced when EXTGLOB_FS flag is passed
   | ExtGlob(List[part_value] part_vals)
 

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 3
+## oils_failures_allowed: 5
 ## compare_shells: bash dash mksh zsh ash yash
 
 #### Fatal error

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -202,7 +202,7 @@ myfunc one "" two
 ## N-I zsh STDOUT:
 ## END
 
-#### Compare $@ in argv to $@ in loop - reduction of case above
+#### Behavior of IFS=x and unquoted $@ - reduction of case above
 case $SH in zsh) exit ;; esac
 
 set -- one "" two

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -305,10 +305,24 @@ onextwoxxthree
 case $SH in zsh) exit ;; esac  # buggy
 
 IFS=x
-cc() { echo =$*=; for i in $*; do echo -$i-; done;}; cc "" ""
-cc() { echo ="$*"=; for i in =$*=; do echo -$i-; done;}; cc "" ""
+
+func1() {
+  echo =$*=
+  for i in $*; do echo -$i-; done
+}
+func1 "" ""
+
+echo
+
+func2() {
+  echo ="$*"=
+  for i in =$*=; do echo -$i-; done
+}
+func2 "" ""
+
 ## STDOUT:
 = =
+
 =x=
 -=-
 -=-
@@ -316,6 +330,7 @@ cc() { echo ="$*"=; for i in =$*=; do echo -$i-; done;}; cc "" ""
 ## BUG bash STDOUT:
 = =
 --
+
 =x=
 -=-
 -=-
@@ -324,6 +339,7 @@ cc() { echo ="$*"=; for i in =$*=; do echo -$i-; done;}; cc "" ""
 = =
 --
 --
+
 =x=
 -=-
 -=-

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -185,18 +185,20 @@ myfunc one "" two
 =ghi=
 ---
 =one=
+==
 =two=
 ## END
-## BUG bash/mksh/yash STDOUT:
+
+## BUG dash/ash STDOUT:
 =one=
 =abc=
 =d f=
 =ghi=
 ---
 =one=
-==
 =two=
 ## END
+
 ## N-I zsh STDOUT:
 ## END
 
@@ -204,30 +206,25 @@ myfunc one "" two
 case $SH in zsh) exit ;; esac
 
 set -- one "" two
-argv.py $@
 
 IFS=x
+
+argv.py $@
+
 for i in $@; do
   echo =$i=
 done
 
 ## STDOUT:
-['one', 'two']
-=one=
-=two=
-## END
-
-## BUG bash/mksh STDOUT:
-['one', 'two']
-=one=
-==
-=two=
-## END
-
-## BUG yash STDOUT:
 ['one', '', 'two']
 =one=
 ==
+=two=
+## END
+
+## BUG dash/ash STDOUT:
+['one', 'two']
+=one=
 =two=
 ## END
 

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -520,8 +520,9 @@ printf "<%s>\n" $x
 
 #### 4 x 3 table: (default IFS, IFS='', IFS=zx) x ( $* "$*" $@ "$@" )
 
-set -- 'a b' c
+set -- 'a b' c ''
 
+# default IFS
 argv.py '  $*  '  $*
 argv.py ' "$*" ' "$*"
 argv.py '  $@  '  $@
@@ -543,17 +544,78 @@ argv.py ' "$@" ' "$@"
 
 ## STDOUT:
 ['  $*  ', 'a', 'b', 'c']
-[' "$*" ', 'a b c']
+[' "$*" ', 'a b c ']
 ['  $@  ', 'a', 'b', 'c']
-[' "$@" ', 'a b', 'c']
+[' "$@" ', 'a b', 'c', '']
 
 ['  $*  ', 'a b', 'c']
 [' "$*" ', 'a bc']
 ['  $@  ', 'a b', 'c']
-[' "$@" ', 'a b', 'c']
+[' "$@" ', 'a b', 'c', '']
 
 ['  $*  ', 'a b', 'c']
-[' "$*" ', 'a bzc']
+[' "$*" ', 'a bzcz']
 ['  $@  ', 'a b', 'c']
-[' "$@" ', 'a b', 'c']
+[' "$@" ', 'a b', 'c', '']
+## END
+
+## BUG yash STDOUT:
+['  $*  ', 'a', 'b', 'c', '']
+[' "$*" ', 'a b c ']
+['  $@  ', 'a', 'b', 'c', '']
+[' "$@" ', 'a b', 'c', '']
+
+['  $*  ', 'a b', 'c', '']
+[' "$*" ', 'a bc']
+['  $@  ', 'a b', 'c', '']
+[' "$@" ', 'a b', 'c', '']
+
+['  $*  ', 'a b', 'c', '']
+[' "$*" ', 'a bzcz']
+['  $@  ', 'a b', 'c', '']
+[' "$@" ', 'a b', 'c', '']
+## END
+
+#### 4 x 3 table - with for loop
+case $SH in yash) exit ;; esac  # no echo -n
+
+set -- 'a b' c ''
+
+# default IFS
+echo -n '  $*  ';  for i in  $*; do echo -n "[$i]"; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n "[$i]"; done; echo
+echo -n '  $@  ';  for i in  $@; do echo -n "[$i]"; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n "[$i]"; done; echo
+echo
+
+IFS=''
+echo -n '  $*  ';  for i in  $*; do echo -n "[$i]"; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n "[$i]"; done; echo
+echo -n '  $@  ';  for i in  $@; do echo -n "[$i]"; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n "[$i]"; done; echo
+echo
+
+IFS=zx
+echo -n '  $*  ';  for i in  $*; do echo -n "[$i]"; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n "[$i]"; done; echo
+echo -n '  $@  ';  for i in  $@; do echo -n "[$i]"; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n "[$i]"; done; echo
+
+## STDOUT:
+  $*  [a][b][c]
+ "$*" [a b c ]
+  $@  [a][b][c]
+ "$@" [a b][c][]
+
+  $*  [a b][c]
+ "$*" [a bc]
+  $@  [a b][c]
+ "$@" [a b][c][]
+
+  $*  [a b][c]
+ "$*" [a bzcz]
+  $@  [a b][c]
+ "$@" [a b][c][]
+## END
+## N-I yash STDOUT:
 ## END

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 6
+## oils_failures_allowed: 7
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -582,40 +582,40 @@ case $SH in yash) exit ;; esac  # no echo -n
 set -- 'a b' c ''
 
 # default IFS
-echo -n '  $*  ';  for i in  $*; do echo -n "[$i]"; done; echo
-echo -n ' "$*" ';  for i in "$*"; do echo -n "[$i]"; done; echo
-echo -n '  $@  ';  for i in  $@; do echo -n "[$i]"; done; echo
-echo -n ' "$@" ';  for i in "$@"; do echo -n "[$i]"; done; echo
+echo -n '  $*  ';  for i in  $*;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n ' '; echo -n -$i-; done; echo
+echo -n '  $@  ';  for i in  $@;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n ' '; echo -n -$i-; done; echo
 echo
 
 IFS=''
-echo -n '  $*  ';  for i in  $*; do echo -n "[$i]"; done; echo
-echo -n ' "$*" ';  for i in "$*"; do echo -n "[$i]"; done; echo
-echo -n '  $@  ';  for i in  $@; do echo -n "[$i]"; done; echo
-echo -n ' "$@" ';  for i in "$@"; do echo -n "[$i]"; done; echo
+echo -n '  $*  ';  for i in  $*;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n ' '; echo -n -$i-; done; echo
+echo -n '  $@  ';  for i in  $@;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n ' '; echo -n -$i-; done; echo
 echo
 
 IFS=zx
-echo -n '  $*  ';  for i in  $*; do echo -n "[$i]"; done; echo
-echo -n ' "$*" ';  for i in "$*"; do echo -n "[$i]"; done; echo
-echo -n '  $@  ';  for i in  $@; do echo -n "[$i]"; done; echo
-echo -n ' "$@" ';  for i in "$@"; do echo -n "[$i]"; done; echo
+echo -n '  $*  ';  for i in  $*;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n ' '; echo -n -$i-; done; echo
+echo -n '  $@  ';  for i in  $@;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n ' '; echo -n -$i-; done; echo
 
 ## STDOUT:
-  $*  [a][b][c]
- "$*" [a b c ]
-  $@  [a][b][c]
- "$@" [a b][c][]
+  $*   -a- -b- -c-
+ "$*"  -a b c -
+  $@   -a- -b- -c-
+ "$@"  -a b- -c- --
 
-  $*  [a b][c]
- "$*" [a bc]
-  $@  [a b][c]
- "$@" [a b][c][]
+  $*   -a b- -c-
+ "$*"  -a bc-
+  $@   -a b- -c-
+ "$@"  -a b- -c- --
 
-  $*  [a b][c]
- "$*" [a bzcz]
-  $@  [a b][c]
- "$@" [a b][c][]
+  $*   -a b- -c-
+ "$*"  -a b c -
+  $@   -a b- -c-
+ "$@"  -a b- -c- --
 ## END
 ## N-I yash STDOUT:
 ## END

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 11
+## oils_failures_allowed: 6
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.
@@ -59,6 +59,18 @@ fun "a 1" "b 2" "c 3"
 #### empty argv
 argv.py 1 "$@" 2 $@ 3 "$*" 4 $* 5
 ## stdout: ['1', '2', '3', '', '4', '5']
+
+#### $* with empty IFS
+set -- "1 2" "3  4"
+
+IFS=
+argv.py $*
+argv.py "$*"
+
+## STDOUT:
+['1 2', '3  4']
+['1 23  4']
+## END
 
 #### Word elision with space
 s1=' '
@@ -337,6 +349,8 @@ printf '[%s]\n' $*
 ## END
 
 #### IFS='' with ${a[@]} and ${a[*]} (bug #627)
+case $SH in dash | ash) exit 0 ;; esac
+
 myarray=(a 'b c')
 IFS=''
 argv.py at ${myarray[@]}
@@ -346,8 +360,44 @@ argv.py star ${myarray[*]}
 ['at', 'a', 'b c']
 ['star', 'a', 'b c']
 ## END
-## N-I dash/ash status: 2
 ## N-I dash/ash stdout-json: ""
+
+#### IFS='' with ${!prefix@} and ${!prefix*} (bug #627)
+case $SH in dash | mksh | ash | yash) exit 0 ;; esac
+
+gLwbmGzS_var1=1
+gLwbmGzS_var2=2
+IFS=''
+argv.py at ${!gLwbmGzS_@}
+argv.py star ${!gLwbmGzS_*}
+
+## STDOUT:
+['at', 'gLwbmGzS_var1', 'gLwbmGzS_var2']
+['star', 'gLwbmGzS_var1', 'gLwbmGzS_var2']
+## END
+## BUG bash STDOUT:
+['at', 'gLwbmGzS_var1', 'gLwbmGzS_var2']
+['star', 'gLwbmGzS_var1gLwbmGzS_var2']
+## END
+## N-I dash/mksh/ash/yash stdout-json: ""
+
+#### IFS='' with ${!a[@]} and ${!a[*]} (bug #627)
+case $SH in dash | mksh | ash | yash) exit 0 ;; esac
+
+IFS=''
+a=(v1 v2 v3)
+argv.py at ${!a[@]}
+argv.py star ${!a[*]}
+
+## STDOUT:
+['at', '0', '1', '2']
+['star', '0', '1', '2']
+## END
+## BUG bash STDOUT:
+['at', '0', '1', '2']
+['star', '0 1 2']
+## END
+## N-I dash/mksh/ash/yash stdout-json: ""
 
 #### Bug #628 split on : with : in literal word
 IFS=':'

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -518,7 +518,7 @@ printf "<%s>\n" $x
 <x>
 ## END
 
-#### 4 x 2 table: (IFS='', default IFS) x ( $* "$*" $@ "$@" )
+#### 4 x 3 table: (default IFS, IFS='', IFS=zx) x ( $* "$*" $@ "$@" )
 
 set -- 'a b' c
 
@@ -533,6 +533,13 @@ argv.py '  $*  '  $*
 argv.py ' "$*" ' "$*"
 argv.py '  $@  '  $@
 argv.py ' "$@" ' "$@"
+echo
+
+IFS=zx
+argv.py '  $*  '  $*
+argv.py ' "$*" ' "$*"
+argv.py '  $@  '  $@
+argv.py ' "$@" ' "$@"
 
 ## STDOUT:
 ['  $*  ', 'a', 'b', 'c']
@@ -542,6 +549,11 @@ argv.py ' "$@" ' "$@"
 
 ['  $*  ', 'a b', 'c']
 [' "$*" ', 'a bc']
+['  $@  ', 'a b', 'c']
+[' "$@" ', 'a b', 'c']
+
+['  $*  ', 'a b', 'c']
+[' "$*" ', 'a bzc']
 ['  $@  ', 'a b', 'c']
 [' "$@" ', 'a b', 'c']
 ## END

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -619,3 +619,46 @@ echo -n ' "$@" ';  for i in "$@"; do echo -n ' '; echo -n -$i-; done; echo
 ## END
 ## N-I yash STDOUT:
 ## END
+
+#### IFS=x and '' and $@ - same bug as spec/toysh-posix case #12
+
+case $SH in yash) exit ;; esac  # no echo -n
+
+set -- one '' two
+
+IFS=zx
+echo -n '  $*  ';  for i in  $*;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$*" ';  for i in "$*"; do echo -n ' '; echo -n -$i-; done; echo
+echo -n '  $@  ';  for i in  $@;  do echo -n ' '; echo -n -$i-; done; echo
+echo -n ' "$@" ';  for i in "$@"; do echo -n ' '; echo -n -$i-; done; echo
+
+argv.py '  $*  '  $*
+argv.py ' "$*" ' "$*"
+argv.py '  $@  '  $@
+argv.py ' "$@" ' "$@"
+
+
+## STDOUT:
+  $*   -one- -- -two-
+ "$*"  -one  two-
+  $@   -one- -- -two-
+ "$@"  -one- -- -two-
+['  $*  ', 'one', '', 'two']
+[' "$*" ', 'onezztwo']
+['  $@  ', 'one', '', 'two']
+[' "$@" ', 'one', '', 'two']
+## END
+
+## BUG dash/ash STDOUT:
+  $*   -one- -two-
+ "$*"  -one  two-
+  $@   -one- -two-
+ "$@"  -one- -- -two-
+['  $*  ', 'one', 'two']
+[' "$*" ', 'onezztwo']
+['  $@  ', 'one', 'two']
+[' "$@" ', 'one', '', 'two']
+## END
+
+## N-I yash STDOUT:
+## END

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -417,7 +417,7 @@ class ExprEvaluator(object):
             elif case(Id.Lit_AtLBracket):  # @[split(x)]
                 strs = val_ops.ToShellArray(val, loc.WordPart(part),
                                             'Expr splice ')
-                return part_value.Array(strs)
+                return part_value.Array(strs, True)
 
             else:
                 raise AssertionError(part.left)


### PR DESCRIPTION
Please see the commit message for the details.

This fixes an issue discussed in DM (Koichi Murase, Andy Chu, 2025-02-16) about the behavior of `$*` with `IFS=`. A related discussion is https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/How.20other.20shells.20implement.20IFS.

By the way, in the testing, I found Bash bugs: `${!prefix*}` and `${!arr[*]}` doesn't follow the rule with `IFS=`, as others `$*` and `${a[*]}` (See the added test cases, spec/word-split 39 and 40).