### PR TITLE
[spec/word-split] Add more failing test cases for `IFS=x; set "" "" ""; $*`

### DIFF
--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -280,7 +280,7 @@ argv.py "$s"
 s=$@
 argv.py "$s"
 
-s"$*"
+s="$*"
 argv.py "$s"
 
 s=$*
@@ -292,7 +292,7 @@ argv.py "$s"
 ## STDOUT:
 ['x y z']
 ['x y z']
-['x y z']
+['x:y z']
 ['x:y z']
 ## END
 ## BUG dash/ash/yash STDOUT:

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 7
+## oils_failures_allowed: 9
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.
@@ -661,4 +661,93 @@ argv.py ' "$@" ' "$@"
 ## END
 
 ## N-I yash STDOUT:
+## END
+
+#### IFS=x and '' and $@ (#2)
+
+set -- "" "" "" "" ""
+argv.py =$@=
+argv.py =$*=
+IFS=
+argv.py =$@=
+argv.py =$*=
+IFS=x
+argv.py =$@=
+argv.py =$*=
+
+## STDOUT:
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+## END
+
+## OK bash/mksh/osh STDOUT:
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+## END
+
+# yash-2.49 seems to behave in a strange way, but this behavior seems to have
+# been fixed at least in yash-2.57.
+
+## BUG yash STDOUT:
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+## END
+
+#### IFS=x and '' and $@ (#3)
+
+IFS=x
+set -- "" "" "" "" ""
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+
+
+## STDOUT:
+[]
+[]
+[]
+[]
+[]
+## END
+
+## OK bash/osh STDOUT:
+['', '', '', '']
+['', '', '']
+['', '']
+['']
+[]
+## END
+
+## OK mksh STDOUT:
+['', '', '']
+['']
+[]
+[]
+[]
+## END
+
+## BUG yash STDOUT:
+['', '', '', '', '']
+['', '', '', '', '']
+['', '', '', '', '']
+['', '', '', '', '']
+['', '', '', '', '']
 ## END


### PR DESCRIPTION
These are follow-up fixes for #2248. This PR also contains a fix to another broken test case: 0187f3bb62f2b0375c789f089a899c988d554673, where `=` of an assignment was missing.

----

Bash's behavior `IFS=x` seems strange to me (see the added test case, where the number of arguments decreases by one every time resetting them). However, even if we report it to the upstream Bash, I guess Chet wouldn't finally change the behavior. This area is the one marked as "*unspecified*" by POSIX, and the behavior among the shells is anyway not consistent. In addition, as far as I look at the codebase of Bash, the fix wouldn't be simple. It would require rewriting multiple places in the Bash codebase. In addition, I guess the impact on the real use cases wouldn't be so significant.

Except for `bash` and `mksh`, all the shells produce no arguments for `$*` with `IFS=x; set "" "" "" "" ""`. Yash in the oils-for-unix test (yash-2.49) seems to produce a distinct result (which preserves the empty elements with `$*`), but Yash has already fixed its behavior to be consistent with the majority (which produces no arguments) at least in yash-2.57.

There would be two options for the design of osh, 1) to replicate Bash's behavior exactly, or 2) to follow the majority of different shells. In this PR, I added the tests as failing tests requesting them to be the same as Bash's, but it doesn't mean I request osh to be consistent with Bash in the future.
