### PR TITLE
[spec/word-split] Add more failing test cases for `IFS=x; set "" "" ""; $*`

### DIFF
--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -202,8 +202,10 @@ myfunc one "" two
 ## N-I zsh STDOUT:
 ## END
 
-#### Behavior of IFS=x and unquoted $@ - reduction of case above
-case $SH in zsh) exit ;; esac
+#### IFS=x and '' and unquoted $@ - reduction of case above
+
+setopt SH_WORD_SPLIT
+#set -x
 
 set -- one "" two
 
@@ -212,24 +214,22 @@ IFS=x
 argv.py $@
 
 for i in $@; do
-  echo =$i=
+  echo -$i-
 done
 
 ## STDOUT:
 ['one', '', 'two']
-=one=
-==
-=two=
+-one-
+--
+-two-
 ## END
 
-## BUG dash/ash STDOUT:
+## BUG dash/ash/zsh STDOUT:
 ['one', 'two']
-=one=
-=two=
+-one-
+-two-
 ## END
 
-## N-I zsh STDOUT:
-## END
 
 #### for loop parsing - http://landley.net/notes.html#04-03-2020
 

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -202,7 +202,7 @@ myfunc one "" two
 ## N-I zsh STDOUT:
 ## END
 
-#### IFS=x and '' and unquoted $@ - reduction of case above
+#### IFS=x and '' and unquoted $@ - reduction of case above - copied into spec/word-split
 
 setopt SH_WORD_SPLIT
 #set -x
@@ -260,14 +260,20 @@ if test $? -ne 0; then echo fail; fi
 
 #### IFS - http://landley.net/notes.html#15-02-2020 (TODO: osh)
 
-IFS=x; A=xabcxx; for i in $A; do echo =$i=; done
+IFS=x
+A=xabcxx
+for i in $A; do echo =$i=; done
+echo
 
-unset IFS; A="   abc   def   "; for i in ""$A""; do echo =$i=; done
+unset IFS
+A="   abc   def   "
+for i in ""$A""; do echo =$i=; done
 
 ## STDOUT:
 ==
 =abc=
 ==
+
 ==
 =abc=
 =def=
@@ -276,8 +282,8 @@ unset IFS; A="   abc   def   "; for i in ""$A""; do echo =$i=; done
 ## BUG zsh status: 1
 ## BUG zsh stdout-json: ""
 
-#### IFS 2 (TODO: osh)
-this one appears different between osh and bash
+#### IFS 2 - copied into spec/word-split
+# this one appears different between osh and bash
 A="   abc   def   "; for i in ""x""$A""; do echo =$i=; done
 
 ## STDOUT:

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -299,12 +299,13 @@ onextwoxxthree
 ## END
 
 #### IFS 4
-case $SH in zsh) exit ;; esac  # buggy
+
+setopt SH_WORD_SPLIT
 
 IFS=x
 
 func1() {
-  echo =$*=
+  echo /$*/
   for i in $*; do echo -$i-; done
 }
 func1 "" ""
@@ -312,36 +313,34 @@ func1 "" ""
 echo
 
 func2() {
-  echo ="$*"=
+  echo /"$*"/
   for i in =$*=; do echo -$i-; done
 }
 func2 "" ""
 
 ## STDOUT:
-= =
+/ /
 
-=x=
+/x/
 -=-
 -=-
 ## END
 ## BUG bash STDOUT:
-= =
+/ /
 --
 
-=x=
+/x/
 -=-
 -=-
 ## END
-## BUG yash STDOUT:
-= =
+## BUG yash/zsh STDOUT:
+/ /
 --
 --
 
-=x=
+/x/
 -=-
 -=-
-## END
-## N-I zsh STDOUT:
 ## END
 
 #### IFS 5

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -280,7 +280,7 @@ argv.py "$s"
 s=$@
 argv.py "$s"
 
-s"$*"
+s="$*"
 argv.py "$s"
 
 s=$*
@@ -292,7 +292,7 @@ argv.py "$s"
 ## STDOUT:
 ['x y z']
 ['x y z']
-['x y z']
+['x:y z']
 ['x:y z']
 ## END
 ## BUG dash/ash/yash STDOUT:

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 7
+## oils_failures_allowed: 9
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.
@@ -661,4 +661,93 @@ argv.py ' "$@" ' "$@"
 ## END
 
 ## N-I yash STDOUT:
+## END
+
+#### IFS=x and '' and $@ (#2)
+
+set -- "" "" "" "" ""
+argv.py =$@=
+argv.py =$*=
+IFS=
+argv.py =$@=
+argv.py =$*=
+IFS=x
+argv.py =$@=
+argv.py =$*=
+
+## STDOUT:
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+## END
+
+## OK bash/mksh/osh STDOUT:
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+## END
+
+# yash-2.49 seems to behave in a strange way, but this behavior seems to have
+# been fixed at least in yash-2.57.
+
+## BUG yash STDOUT:
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+['=', '', '', '', '=']
+## END
+
+#### IFS=x and '' and $@ (#3)
+
+IFS=x
+set -- "" "" "" "" ""
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+
+
+## STDOUT:
+[]
+[]
+[]
+[]
+[]
+## END
+
+## OK bash/osh STDOUT:
+['', '', '', '']
+['', '', '']
+['', '']
+['']
+[]
+## END
+
+## OK mksh STDOUT:
+['', '', '']
+['']
+[]
+[]
+[]
+## END
+
+## BUG yash STDOUT:
+['', '', '', '', '']
+['', '', '', '', '']
+['', '', '', '', '']
+['', '', '', '', '']
+['', '', '', '', '']
 ## END

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 6
+## oils_failures_allowed: 7
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.
@@ -789,4 +789,41 @@ argv.py $*
 ['', '', '', '', '']
 ['', '', '', '', '']
 ['', '', '', '', '']
+## END
+
+#### ""$A"" - empty string on both sides - derived from spec/toysh-posix #15
+
+A="   abc   def   "
+for i in $A; do echo =$i=; done
+echo
+
+A="   abc   def   "
+for i in ""$A""; do echo =$i=; done
+echo
+
+unset IFS
+
+A="   abc   def   "
+for i in $A; do echo =$i=; done
+echo
+
+A="   abc   def   "
+for i in ""$A""; do echo =$i=; done
+
+## STDOUT:
+=abc=
+=def=
+
+==
+=abc=
+=def=
+==
+
+=abc=
+=def=
+
+==
+=abc=
+=def=
+==
 ## END

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 9
+## oils_failures_allowed: 6
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.
@@ -665,7 +665,7 @@ argv.py '  $@  '  $@
 argv.py ' "$@" ' "$@"
 
 
-## STDOUT:
+## OK bash/mksh STDOUT:
   $*   -one- -- -two-
  "$*"  -one  two-
   $@   -one- -- -two-
@@ -676,7 +676,7 @@ argv.py ' "$@" ' "$@"
 [' "$@" ', 'one', '', 'two']
 ## END
 
-## BUG dash/ash STDOUT:
+## STDOUT:
   $*   -one- -two-
  "$*"  -one  two-
   $@   -one- -two-

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -520,6 +520,8 @@ printf "<%s>\n" $x
 
 #### 4 x 3 table: (default IFS, IFS='', IFS=zx) x ( $* "$*" $@ "$@" )
 
+setopt SH_WORD_SPLIT  # for zsh
+
 set -- 'a b' c ''
 
 # default IFS
@@ -559,6 +561,27 @@ argv.py ' "$@" ' "$@"
 [' "$@" ', 'a b', 'c', '']
 ## END
 
+# zsh disagrees on
+# - $@ with default IFS an
+# - $@ with IFS=zx
+
+## BUG zsh STDOUT:
+['  $*  ', 'a', 'b', 'c']
+[' "$*" ', 'a b c ']
+['  $@  ', 'a b', 'c']
+[' "$@" ', 'a b', 'c', '']
+
+['  $*  ', 'a b', 'c']
+[' "$*" ', 'a bc']
+['  $@  ', 'a b', 'c']
+[' "$@" ', 'a b', 'c', '']
+
+['  $*  ', 'a b', 'c', '']
+[' "$*" ', 'a bzcz']
+['  $@  ', 'a b', 'c']
+[' "$@" ', 'a b', 'c', '']
+## END
+
 ## BUG yash STDOUT:
 ['  $*  ', 'a', 'b', 'c', '']
 [' "$*" ', 'a b c ']
@@ -578,6 +601,8 @@ argv.py ' "$@" ' "$@"
 
 #### 4 x 3 table - with for loop
 case $SH in yash) exit ;; esac  # no echo -n
+
+setopt SH_WORD_SPLIT  # for zsh
 
 set -- 'a b' c ''
 
@@ -617,12 +642,14 @@ echo -n ' "$@" ';  for i in "$@"; do echo -n ' '; echo -n -$i-; done; echo
   $@   -a b- -c-
  "$@"  -a b- -c- --
 ## END
+
 ## N-I yash STDOUT:
 ## END
 
 #### IFS=x and '' and $@ - same bug as spec/toysh-posix case #12
-
 case $SH in yash) exit ;; esac  # no echo -n
+
+setopt SH_WORD_SPLIT  # for zsh
 
 set -- one '' two
 
@@ -664,6 +691,7 @@ argv.py ' "$@" ' "$@"
 ## END
 
 #### IFS=x and '' and $@ (#2)
+setopt SH_WORD_SPLIT  # for zsh
 
 set -- "" "" "" "" ""
 argv.py =$@=
@@ -706,6 +734,7 @@ argv.py =$*=
 ## END
 
 #### IFS=x and '' and $@ (#3)
+setopt SH_WORD_SPLIT  # for zsh
 
 IFS=x
 set -- "" "" "" "" ""
@@ -744,7 +773,7 @@ argv.py $*
 []
 ## END
 
-## BUG yash STDOUT:
+## BUG zsh/yash STDOUT:
 ['', '', '', '', '']
 ['', '', '', '', '']
 ['', '', '', '', '']

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -696,9 +696,13 @@ setopt SH_WORD_SPLIT  # for zsh
 set -- "" "" "" "" ""
 argv.py =$@=
 argv.py =$*=
+echo
+
 IFS=
 argv.py =$@=
 argv.py =$*=
+echo
+
 IFS=x
 argv.py =$@=
 argv.py =$*=
@@ -706,17 +710,21 @@ argv.py =$*=
 ## STDOUT:
 ['=', '=']
 ['=', '=']
+
 ['=', '=']
 ['=', '=']
+
 ['=', '=']
 ['=', '=']
 ## END
 
-## OK bash/mksh/osh STDOUT:
+## OK bash/mksh STDOUT:
 ['=', '=']
 ['=', '=']
+
 ['=', '=']
 ['=', '=']
+
 ['=', '', '', '', '=']
 ['=', '', '', '', '=']
 ## END
@@ -727,8 +735,10 @@ argv.py =$*=
 ## BUG yash STDOUT:
 ['=', '', '', '', '=']
 ['=', '', '', '', '=']
+
 ['=', '', '', '', '=']
 ['=', '', '', '', '=']
+
 ['=', '', '', '', '=']
 ['=', '', '', '', '=']
 ## END
@@ -738,16 +748,16 @@ setopt SH_WORD_SPLIT  # for zsh
 
 IFS=x
 set -- "" "" "" "" ""
-argv.py $*
-set -- $*
-argv.py $*
-set -- $*
-argv.py $*
-set -- $*
-argv.py $*
-set -- $*
-argv.py $*
 
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
+set -- $*
+argv.py $*
 
 ## STDOUT:
 []
@@ -757,7 +767,7 @@ argv.py $*
 []
 ## END
 
-## OK bash/osh STDOUT:
+## OK bash STDOUT:
 ['', '', '', '']
 ['', '', '']
 ['', '']


### PR DESCRIPTION
These are follow-up fixes for #2248. This PR also contains a fix to another broken test case: 0187f3bb62f2b0375c789f089a899c988d554673, where `=` of an assignment was missing.

----

Bash's behavior `IFS=x` seems strange to me (see the added test case, where the number of arguments decreases by one every time resetting them). However, even if we report it to the upstream Bash, I guess Chet wouldn't finally change the behavior. This area is the one marked as "*unspecified*" by POSIX, and the behavior among the shells is anyway not consistent. In addition, as far as I look at the codebase of Bash, the fix wouldn't be simple. It would require rewriting multiple places in the Bash codebase. In addition, I guess the impact on the real use cases wouldn't be so significant.

Except for `bash` and `mksh`, all the shells produce no arguments for `$*` with `IFS=x; set "" "" "" "" ""`. Yash in the oils-for-unix test (yash-2.49) seems to produce a distinct result (which preserves the empty elements with `$*`), but Yash has already fixed its behavior to be consistent with the majority (which produces no arguments) at least in yash-2.57.

There would be two options for the design of osh, 1) to replicate Bash's behavior exactly, or 2) to follow the majority of different shells. In this PR, I added the tests as failing tests requesting them to be the same as Bash's, but it doesn't mean I request osh to be consistent with Bash in the future.
