### PR TITLE
[bash_impl] SparseArray: omit index in the printed form in the dense case

### DIFF
--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -464,12 +464,15 @@ def SparseArray_Equals(lhs, rhs):
 def SparseArray_ToStrForShellPrint(sparse_val):
     # type: (value.SparseArray) -> str
     body = []  # type: List[str]
+
+    is_sparse = not mops.Equal(mops.IntWiden(SparseArray_Count(sparse_val)),
+                               SparseArray_Length(sparse_val))
+
     for index in SparseArray_GetKeys(sparse_val):
         if len(body) > 0:
             body.append(" ")
-        body.extend([
-            "[",
-            mops.ToStr(index), "]=",
-            j8_lite.MaybeShellEncode(sparse_val.d[index])
-        ])
+        if is_sparse:
+            body.extend(["[", mops.ToStr(index), "]="])
+
+        body.append(j8_lite.MaybeShellEncode(sparse_val.d[index]))
     return "(%s)" % ''.join(body)

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -384,8 +384,8 @@ declare -p a0 a1 a2 sp
 
 ## STDOUT:
 declare -a a0=()
-declare -a a1=([0]=1)
-declare -a a2=([0]=1 [1]=2)
+declare -a a1=(1)
+declare -a a2=(1 2)
 declare -a sp=([0]=x [1]=y [2]=z [3]=w [500]=100 [1000]=100)
 ## END
 
@@ -582,7 +582,7 @@ unset -v "a[0]"
 declare -p a
 
 ## STDOUT:
-declare -a a=([0]=1 [1]=2 [2]=3 [3]=4 [4]=5 [5]=6 [6]=7 [7]=8 [8]=9)
+declare -a a=(1 2 3 4 5 6 7 8 9)
 declare -a a=([0]=1 [2]=3 [3]=4 [4]=5 [5]=6 [6]=7 [7]=8 [8]=9)
 declare -a a=([0]=1 [2]=3 [3]=4 [4]=5 [5]=6 [6]=7 [7]=8 [8]=9)
 declare -a a=([2]=3 [3]=4 [4]=5 [5]=6 [6]=7 [7]=8 [8]=9)
@@ -631,8 +631,8 @@ a[-1]=x
 declare -p a
 
 ## STDOUT:
-declare -a a=([0]=1 [1]=2 [2]=3 [3]=4 [4]=5 [5]=6 [6]=7 [7]=x)
-declare -a a=([0]=1 [1]=2 [2]=3 [3]=4 [4]=5 [5]=6 [6]=x)
+declare -a a=(1 2 3 4 5 6 7 x)
+declare -a a=(1 2 3 4 5 6 x)
 ## END
 
 ## N-I bash/zsh/mksh/ash STDOUT:


### PR DESCRIPTION
For a smoother transition of the indexed-array internal representation from `BashArray` to `SparseArray`, I here suggest switching the printed form of `SparseArray` (used by `declare -p` and other places) based on whether it is indeed "sparse" or not.

- The current behavior of `SparseArray`:
  - It always uses the designated array initializer form: `([0]=1 [1]=2 [4]=5 ...)`
- This PR modifies the behavior as follows:
  - When it is dense (i.e., when all the indices up to `max_index` are filled), it would use the same printed form as the present `BashArray`: `(1 2 3 4 5 ...)` 
  - When it is sparse (i.e., when there is a "hole"), it would use the designated array initializer form: `([0]=1 [1]=2 [4]=5 ...)`

Even though we currently do not support the designated initializer syntax (`([index]=value)`) for indexed arrays, I'm going to work on *the initializer list* [[ref1](https://github.com/oils-for-unix/oils/issues/661#issuecomment-599334537), [ref2](https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/2024-11-22.20Meeting/near/485170417)] after the transition to `SparseArray` is complete. Then, everything should become fine finally.