### PR TITLE
[osh] switch the default indexed array from `BashArray` to `SparseArray`

### DIFF
--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -226,7 +226,8 @@ class Append(vm._Builtin):
                          for s in arg_r.Rest()]  # type: List[value_t]
                 val.items.extend(typed)
             else:
-                raise error.TypeErr(val, 'expected List or BashArray',
-                                    loc.Missing)
+                raise error.TypeErr(
+                    val, 'expected List, BashArray, or SparseArray',
+                    loc.Missing)
 
         return 0

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -344,6 +344,19 @@ def BashAssoc_ToStrForShellPrint(assoc_val):
 # SparseArray come here.
 
 
+def SparseArray_FromList(strs):
+    # type: (List[str]) -> value.SparseArray
+
+    d = {}  # type: Dict[mops.BigInt, str]
+    max_index = mops.MINUS_ONE  # max index for empty array
+    for s in strs:
+        max_index = mops.Add(max_index, mops.ONE)
+        if s is not None:
+            d[max_index] = s
+
+    return value.SparseArray(d, max_index)
+
+
 def SparseArray_IsEmpty(sparse_val):
     # type: (value.SparseArray) -> bool
     return len(sparse_val.d) == 0

--- a/core/completion_test.py
+++ b/core/completion_test.py
@@ -794,9 +794,9 @@ class InitCompletionTest(unittest.TestCase):
 
             # Our test shell script records what passed in an array.
             val = mem.GetValue('PASSED')
-            self.assertEqual(value_e.BashArray, val.tag(),
+            self.assertEqual(value_e.SparseArray, val.tag(),
                              "[case %d] Expected array, got %s" % (i, val))
-            actually_passed = val.strs
+            actually_passed = val.d.values()
 
             should_pass = [
                 'COMP_WORDS',

--- a/core/state.py
+++ b/core/state.py
@@ -2083,7 +2083,7 @@ class Mem(object):
         no_str = None  # type: Optional[str]
         items = [no_str] * lval.index
         items.append(val.s)
-        new_value = value.BashArray(items)
+        new_value = bash_impl.SparseArray_FromList(items)
 
         # arrays can't be exported; can't have BashAssoc flag
         readonly = bool(flags & SetReadOnly)
@@ -2751,7 +2751,8 @@ def BuiltinSetArray(mem, name, a):
     Used by compadjust, read -a, etc.
     """
     assert isinstance(a, list)
-    BuiltinSetValue(mem, location.LName(name), value.BashArray(a))
+    BuiltinSetValue(mem, location.LName(name),
+                    bash_impl.SparseArray_FromList(a))
 
 
 def SetGlobalString(mem, name, s):
@@ -2766,7 +2767,8 @@ def SetGlobalArray(mem, name, a):
     # type: (Mem, str, List[str]) -> None
     """Used by completion, shell initialization, etc."""
     assert isinstance(a, list)
-    mem.SetNamed(location.LName(name), value.BashArray(a), scope_e.GlobalOnly)
+    mem.SetNamed(location.LName(name), bash_impl.SparseArray_FromList(a),
+                 scope_e.GlobalOnly)
 
 
 def SetGlobalValue(mem, name, val):

--- a/core/state_test.py
+++ b/core/state_test.py
@@ -192,8 +192,8 @@ class MemTest(unittest.TestCase):
         mem.SetValue(location.LName('COMPREPLY'),
                      bash_impl.SparseArray_FromList(['1', '2', '3']),
                      scope_e.GlobalOnly)
-        self.assertEqual(['1', '2', '3'],
-                         mem.var_stack[0]['COMPREPLY'].val.strs)
+        compreply_val = mem.var_stack[0]['COMPREPLY'].val
+        self.assertEqual(['1', '2', '3'], sorted(compreply_val.d.values()))
 
         # export COMPREPLY - allowed when strict_array not set
         mem.SetValue(location.LName('COMPREPLY'),
@@ -237,11 +237,11 @@ class MemTest(unittest.TestCase):
         lhs = sh_lvalue.Indexed('a', 1, runtime.NO_SPID)
         # a[1]=2
         mem.SetValue(lhs, value.Str('2'), scope_e.Dynamic)
-        self.assertEqual([None, '2'], mem.var_stack[0]['a'].val.strs)
+        self.assertEqual(['2'], mem.var_stack[0]['a'].val.d.values())
 
         # a[1]=3
         mem.SetValue(lhs, value.Str('3'), scope_e.Dynamic)
-        self.assertEqual([None, '3'], mem.var_stack[0]['a'].val.strs)
+        self.assertEqual(['3'], mem.var_stack[0]['a'].val.d.values())
 
         # a[1]=(x y z)  # illegal but doesn't parse anyway
         if 0:

--- a/core/state_test.py
+++ b/core/state_test.py
@@ -9,6 +9,7 @@ from _devbuild.gen.runtime_asdl import scope_e
 from _devbuild.gen.syntax_asdl import source, SourceLine
 from _devbuild.gen.value_asdl import (value, value_e, sh_lvalue)
 from asdl import runtime
+from core import bash_impl
 from core import error
 from core import executor
 from core import test_lib
@@ -189,7 +190,8 @@ class MemTest(unittest.TestCase):
         # COMPREPLY=(1 2 3)
         # invariant to enforce: arrays can't be exported
         mem.SetValue(location.LName('COMPREPLY'),
-                     value.BashArray(['1', '2', '3']), scope_e.GlobalOnly)
+                     bash_impl.SparseArray_FromList(['1', '2', '3']),
+                     scope_e.GlobalOnly)
         self.assertEqual(['1', '2', '3'],
                          mem.var_stack[0]['COMPREPLY'].val.strs)
 

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -1092,8 +1092,9 @@ class BoolEvaluator(ArithEvaluator):
                 pass
 
                 if self.exec_opts.strict_word_eval():
-                    raise error.TypeErr(val, 'Expected BashArray or BashAssoc',
-                                        blame_loc)
+                    raise error.TypeErr(
+                        val, 'Expected BashArray, SparseArray, or BashAssoc',
+                        blame_loc)
                 return False
         raise AssertionError()
 

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -2165,7 +2165,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 array_words = part0.words
                 words = braces.BraceExpandWords(array_words)
                 strs = self.EvalWordSequence(words)
-                return value.BashArray(strs)
+                return bash_impl.SparseArray_FromList(strs)
 
             if tag == word_part_e.BashAssocLiteral:
                 part0 = cast(word_part.BashAssocLiteral, UP_part0)

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1016,7 +1016,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
                 else:
                     raise error.TypeErr(
-                        val, 'Unary op expected Str, BashArray, BashAssoc',
+                        val,
+                        'Unary op expected Str, BashArray, SparseArray, or BashAssoc',
                         op.op)
 
         else:
@@ -1077,7 +1078,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
             else:
                 raise error.TypeErr(
-                    val, 'Pat Sub op expected Str, BashArray, BashAssoc',
+                    val,
+                    'Pat Sub op expected Str, BashArray, SparseArray, or BashAssoc',
                     op.slash_tok)
 
         return val
@@ -1352,9 +1354,10 @@ class AbstractWordEvaluator(StringWordEvaluator):
                     val = value.Str(s)
 
             else:
-                raise error.TypeErr(val,
-                                    'Index op expected BashArray, BashAssoc',
-                                    loc.WordPart(part))
+                raise error.TypeErr(
+                    val,
+                    'Index op expected BashArray, SparseArray, or BashAssoc',
+                    loc.WordPart(part))
 
         return val
 

--- a/spec/array-compat.test.sh
+++ b/spec/array-compat.test.sh
@@ -103,7 +103,7 @@ argv.py "${a[*]#-}"
 ## N-I mksh status: 1
 ## N-I mksh stdout-json: ""
 
-#### value.BashArray internal representation - Indexed
+#### value.SparseArray internal representation - Indexed
 
 case $SH in mksh) exit ;; esac
 
@@ -156,7 +156,7 @@ status=1
 ## N-I mksh STDOUT:
 ## END
 
-#### value.BashArray internal representation - Assoc (ordering is a problem)
+#### value.SparseArray internal representation - Assoc (ordering is a problem)
 
 case $SH in mksh) exit ;; esac
 

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -869,7 +869,7 @@ mksh: <stdin>[2]: syntax error: 'e[-1]' unexpected operator/operand
 ## END
 
 
-#### a+=() modifies existing instance of BashArray
+#### a+=() modifies existing instance of SparseArray
 case $SH in mksh|bash) exit ;; esac
 
 a=(1 2 3)

--- a/spec/assign-extended.test.sh
+++ b/spec/assign-extended.test.sh
@@ -1,4 +1,5 @@
 ## compare_shells: bash-4.4 mksh
+## oils_failures_allowed: 1
 
 # Extended assignment language, e.g. typeset, declare, arrays, etc.
 # Things that dash doesn't support.
@@ -376,7 +377,7 @@ declare -A test_arr3=()
 declare -a test_arr4=(1 2 3)
 declare -a test_arr5=(1 2 3)
 declare -A test_arr6=(['a']=1 ['b']=2 ['c']=3)
-declare -a test_arr7=(); test_arr7[3]=foo
+declare -a test_arr7=([3]=foo)
 ## END
 ## OK bash STDOUT:
 declare -a test_arr1=()

--- a/spec/ysh-builtin-meta.test.sh
+++ b/spec/ysh-builtin-meta.test.sh
@@ -245,7 +245,7 @@ array = (Cell
   exported:F
   readonly:F
   nameref:F
-  val:(value.BashArray strs:[_ _ _ 42 _ 99])
+  val:(value.SparseArray d:{3 42 5 99} max_index:5)
 )
 ## END
 
@@ -292,7 +292,7 @@ pp [42] | sed 's/0x[a-f0-9]\+/[replaced]/'
 [ stdin ]:5: <Expr [replaced]>
 ## END
 
-#### pp test_ supports BashArray, BashAssoc
+#### pp test_ supports SparseArray, BashAssoc
 
 declare -a array=(a b c)
 pp test_ (array)
@@ -309,8 +309,8 @@ assoc['k3']=
 pp test_ (assoc)
 
 ## STDOUT:
-{"type":"BashArray","data":{"0":"a","1":"b","2":"c"}}
-{"type":"BashArray","data":{"0":"a","1":"b","2":"c","5":"z"}}
+{"type":"SparseArray","data":{"0":"a","1":"b","2":"c"}}
+{"type":"SparseArray","data":{"0":"a","1":"b","2":"c","5":"z"}}
 {"type":"BashAssoc","data":{"k":"v","k2":"v2"}}
 {"type":"BashAssoc","data":{"k":"v","k2":"v2","k3":""}}
 ## END

--- a/spec/ysh-builtins.test.sh
+++ b/spec/ysh-builtins.test.sh
@@ -1,6 +1,6 @@
 ## oils_failures_allowed: 3
 
-#### append onto BashArray a=(1 2)
+#### append onto SparseArray a=(1 2)
 shopt -s parse_at
 a=(1 2)
 append '3 4' '5' (a)

--- a/spec/ysh-expr-bool.test.sh
+++ b/spec/ysh-expr-bool.test.sh
@@ -159,7 +159,7 @@ OR
 AND
 ## END
 
-#### or BashArray, or BashAssoc
+#### or SparseArray, or BashAssoc
 declare -a array=(1 2 3)
 pp test_ (array or 'yy')
 
@@ -167,7 +167,7 @@ declare -A assoc=([k]=v)
 pp test_ (assoc or 'zz')
 
 ## STDOUT:
-{"type":"BashArray","data":{"0":"1","1":"2","2":"3"}}
+{"type":"SparseArray","data":{"0":"1","1":"2","2":"3"}}
 {"type":"BashAssoc","data":{"k":"v"}}
 ## END
 

--- a/spec/ysh-expr.test.sh
+++ b/spec/ysh-expr.test.sh
@@ -26,7 +26,7 @@ echo $length
 3
 ## END
 
-#### Length doesn't apply to BashArray
+#### Length doesn't apply to SparseArray
 x=(a b c)
 x[10]=A
 x[20]=B

--- a/spec/ysh-json.test.sh
+++ b/spec/ysh-json.test.sh
@@ -1202,7 +1202,7 @@ pp test_ (_reply)
 ## STDOUT:
 ## END
 
-#### BashArray can be serialized
+#### SparseArray can be serialized
 
 declare -a empty_array
 
@@ -1214,11 +1214,11 @@ json write (array)
 
 ## STDOUT:
 {
-  "type": "BashArray",
+  "type": "SparseArray",
   "data": {}
 }
 {
-  "type": "BashArray",
+  "type": "SparseArray",
   "data": {
     "0": "x",
     "1": "y",

--- a/spec/ysh-printing.test.sh
+++ b/spec/ysh-printing.test.sh
@@ -120,7 +120,7 @@ pp test_ ({k: array_1})
 (Dict)   {"k":{"type":"SparseArray","data":{"0":"hello","5":"5"}}}
 ## END
 
-#### BashArray, short
+#### SparseArray, short
 declare -a empty=()
 declare -a array_1=(hello)
 
@@ -140,20 +140,20 @@ pp test_ ({k: empty})
 pp test_ ({k: array_1})
 
 ## STDOUT:
-(BashArray)
-(BashArray 'hello')
+(SparseArray)
+(SparseArray [0]='hello')
 
-(Dict)  {k: (BashArray)}
-(Dict)  {k: (BashArray 'hello')}
+(Dict)  {k: (SparseArray)}
+(Dict)  {k: (SparseArray [0]='hello')}
 
-{"type":"BashArray","data":{}}
-{"type":"BashArray","data":{"0":"hello"}}
+{"type":"SparseArray","data":{}}
+{"type":"SparseArray","data":{"0":"hello"}}
 
-(Dict)   {"k":{"type":"BashArray","data":{}}}
-(Dict)   {"k":{"type":"BashArray","data":{"0":"hello"}}}
+(Dict)   {"k":{"type":"SparseArray","data":{}}}
+(Dict)   {"k":{"type":"SparseArray","data":{"0":"hello"}}}
 ## END
 
-#### BashArray, long
+#### SparseArray, long
 declare -a array_3
 array_3[0]="world"
 array_3[2]=*.py
@@ -162,11 +162,19 @@ do eiusmod.)
 = array_3
 = array_long
 ## STDOUT:
-(BashArray 'world' null '*.py')
-(BashArray
-    'Lorem'       'ipsum'       'dolor'       'sit'         'amet,'
-    'consectetur' 'adipiscing'  'elit,'       'sed'         'do'
-    'eiusmod.'
+(SparseArray [0]='world' [2]='*.py')
+(SparseArray
+    [0]='Lorem'
+    [1]='ipsum'
+    [2]='dolor'
+    [3]='sit'
+    [4]='amet,'
+    [5]='consectetur'
+    [6]='adipiscing'
+    [7]='elit,'
+    [8]='sed'
+    [9]='do'
+    [10]='eiusmod.'
 )
 ## END
 

--- a/spec/ysh-with-sh.test.sh
+++ b/spec/ysh-with-sh.test.sh
@@ -171,7 +171,7 @@ declare -a array=(a b)
 array[5]=c
 argv.py "${array[@]}"
 
-# TODO: Should print this like this bash, with value.BashArray
+# TODO: Should print this like this bash, with value.SparseArray
 declare -a
 
 for i, item in (array) {
@@ -181,7 +181,7 @@ for i, item in (array) {
 ## status: 3
 ## STDOUT:
 ['a', 'b', 'c']
-array=(); array[0]=a array[1]=b array[5]=c
+array=([0]=a [1]=b [5]=c)
 ## END
 
 #### Slice bash array isn't allowed


### PR DESCRIPTION
This PR changes the default indexed array representation from `BashArray` to `SparseArray`.

This PR also includes the adjustments to the spec test cases. Some of the rewrite will finally be *effectively* reverted on the renaming of SparseArray to BashArray, but to avoid confusion and inconsistency, we anyway properly update them. For the same reason, this PR also includes adjustments to the error messages. Those error messages will also be somehow reverted, but we want to include the adjustments to error messages within this PR to make the later renaming PR consistent.

### Remaining BashArray

This PR doesn't completely remove the use of `BashArray` because it seems to make more sense to use the simpler representation for some specific internal uses. For example, in processing `"$@"` and `"${a[@]}"`, they are first converted to `BashArray` and then additional modifications are applied. It seems overkill to use `SparseArray` (which internally uses a hash table and requires sorting keys when enumerating elements) just to hold a simple word list. Also, access to special variables like `FUNCNAME` creates BashArray instead of SparseArray because these special variables are ensured to be dense, and generating SparseArray on every access to the variable seems also overkill.

### Out-of-scope: Renaming SparseArray -> BashArray

Renaming of `(SparseArray, BashArray)` to `(BashArray, e.g. BashFlatArray)` is intentionally excluded from this PR because it would make it difficult to focus on the substantial changes. I'll submit the change of the simple renaming in a separate PR after this is merged.


