### PR TITLE
[test/ble.sh] Add "--lib" in loading "out/ble.osh"

### DIFF
--- a/test/ble.sh
+++ b/test/ble.sh
@@ -73,7 +73,7 @@ HISTFILE=$HOME/.osh_history
 #	lib/test-canvas.sh \
 
 for script in \
-  out/ble.osh \
+  "out/ble.osh --lib" \
 	lib/test-main.sh \
 	lib/test-util.sh \
 	lib/test-decode.sh


### PR DESCRIPTION
I rebased the `osh` branch in the upstream `akinomyoga/ble.sh` on the latest version of `ble.sh`.  As a consequence, sourcing `out/ble.osh` in the CI has started to fail (see Run 9147's [`ble-test-osh-py.txt`](https://op.oilshell.org/uuu/github-jobs/9147/app-tests.wwz/_tmp/soil/logs/ble-test-osh-py.txt) and [`ble-test-osh-cpp.txt`](https://op.oilshell.org/uuu/github-jobs/9147/app-tests.wwz/_tmp/soil/logs/ble-test-osh-cpp.txt)).

The latest version of `ble.sh` checks whether the current session has an associated TTY when loaded as an interactive setting.  When `ble.sh` cannot detect the TTY, it cancels its loading.  To load `ble.sh` in a non-interactive session, one needs to source `ble.sh` using "the library mode" by specifying the option `--lib`.