### PR TITLE
[builtin/assign_osh] Fix `readonly` failing to create arrays with -a/-A

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -192,8 +192,8 @@ def _PrintVariables(mem, cmd_val, attrs, print_flags, builtin=_OTHER):
         return 1
 
 
-def _ExportReadonly(mem, pair, flags):
-    # type: (Mem, AssignArg, int) -> None
+def _ExportReadonly(mem, rval, pair, flags):
+    # type: (Mem, value_t, AssignArg, int) -> None
     """For 'export' and 'readonly' to respect += and flags.
 
     Like 'setvar' (scope_e.LocalOnly), unless dynamic scope is on.  That is, it
@@ -208,11 +208,11 @@ def _ExportReadonly(mem, pair, flags):
         old_val = sh_expr_eval.OldValue(lval, mem, None)  # ignore set -u
         # When 'export e+=', then rval is value.Str('')
         # When 'export foo', the pair.plus_eq flag is false.
-        assert pair.rval is not None
-        val = cmd_eval.PlusEquals(old_val, pair.rval)
+        assert rval is not None
+        val = cmd_eval.PlusEquals(old_val, rval)
     else:
         # NOTE: when rval is None, only flags are changed
-        val = pair.rval
+        val = rval
 
     mem.SetNamed(lval, val, which_scopes, flags=flags)
 
@@ -261,7 +261,7 @@ class Export(vm._AssignBuiltin):
                 self.mem.ClearFlag(pair.var_name, state.ClearExport)
         else:
             for pair in cmd_val.pairs:
-                _ExportReadonly(self.mem, pair, state.SetExport)
+                _ExportReadonly(self.mem, pair.rval, pair, state.SetExport)
 
         return 0
 
@@ -336,7 +336,7 @@ class Readonly(vm._AssignBuiltin):
             # NOTE:
             # - when rval is None, only flags are changed
             # - dynamic scope because flags on locals can be changed, etc.
-            _ExportReadonly(self.mem, pair, state.SetReadOnly)
+            _ExportReadonly(self.mem, rval, pair, state.SetReadOnly)
 
         return 0
 

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -672,3 +672,39 @@ dict:3
 ## N-I dash/mksh status: 99
 ## N-I dash/mksh stdout-json: ""
 
+
+#### "declare -a arr" and "readonly -a a" creates an empty array (OSH)
+case $SH in (dash|mksh) exit 99;; esac # dash/mksh does not support associative arrays
+
+declare -a arr1
+readonly -a arr2
+declare -A dict1
+readonly -A dict2
+
+declare -p arr1 arr2 dict1 dict2
+## STDOUT:
+declare -a arr1=()
+declare -ra arr2=()
+declare -A dict1=()
+declare -rA dict2=()
+## END
+## N-I bash STDOUT:
+declare -a arr1
+declare -r arr2
+declare -A dict1
+declare -r dict2
+## END
+## OK zsh STDOUT:
+typeset -a arr1
+arr1=(  )
+typeset -a arr2
+arr2=(  )
+typeset -ar arr2
+typeset -A dict1
+dict1=( )
+typeset -a dict2
+dict2=( )
+typeset -Ar dict2
+## END
+## N-I dash/mksh status: 99
+## N-I dash/mksh stdout-json: ""


### PR DESCRIPTION
There is a dead code:

https://github.com/oils-for-unix/oils/blob/24146f4b0a223354c5f2e42e59cad00358ff82a5/builtin/assign_osh.py#L322-L334

The value of `rval` calculated in the above lines is not used anywhere. The next line only uses the original value `pair.rval`:

https://github.com/oils-for-unix/oils/blob/24146f4b0a223354c5f2e42e59cad00358ff82a5/builtin/assign_osh.py#L339

This is a regression introduced in [this hunk in commit `fd47f77`](https://github.com/oils-for-unix/oils/commit/fd47f772e49b2217c603a834e0521227e6ec2759#diff-81b973a51b80c984cbe64b92eb65bc97b31b7ce89fcd54920b7ed952410e3e85L291).

In fact, we can confirm that the `readonly` builtin doesn't behave in the expected way:

```console
$ bin/osh -c 'declare -a a; declare -p a'
declare -a a=()
$ bin/osh -c 'declare -A a; declare -p a'
declare -A a=()
$ bin/osh -c 'readonly -a a; declare -p a'
$ bin/osh -c 'readonly -A a; declare -p a'
$
```

This PR adds a spec test case and fixes an issue.