### PR TITLE
[refactor osh/cmd_eval] Assert RHS of `ShAssignment` is not `None`

### DIFF
--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -973,8 +973,13 @@ class CommandEvaluator(object):
         which_scopes = self.mem.ScopesForWriting()
 
         for pair in node.pairs:
+            # The shell assignments should always have RHS.  An AssignPair
+            # stored in command_e.ShAssignment is constructed in
+            # cmd_parse._MakeAssignPair, where rhs is explicitly constructed to
+            # be CompoundWord or rhs_word.Empty.
+            assert pair.rhs, pair.rhs
+
             if pair.op == assign_op_e.PlusEqual:
-                assert pair.rhs, pair.rhs  # I don't think a+= is valid?
                 rhs = self.word_ev.EvalRhsWord(pair.rhs)
 
                 lval = self.arith_ev.EvalShellLhs(pair.lhs, which_scopes)
@@ -987,12 +992,8 @@ class CommandEvaluator(object):
                 lval = self.arith_ev.EvalShellLhs(pair.lhs, which_scopes)
 
                 # RHS can be a string or array.
-                if pair.rhs:
-                    rhs = self.word_ev.EvalRhsWord(pair.rhs)
-                    assert isinstance(rhs, value_t), rhs
-
-                else:  # e.g. 'readonly x' or 'local x'
-                    rhs = None
+                rhs = self.word_ev.EvalRhsWord(pair.rhs)
+                assert isinstance(rhs, value_t), rhs
 
                 val = rhs
 


### PR DESCRIPTION
Before implementing the initializer-list approach to the assignment of the form `name=(...)`, I'd like to confirm the assumptions in the relevant places in the codebase.

In the function `cmd_eval._DoShAssignment`, there is a code path to handle the case where the RHS of ShAssignment is None, but is there a real case for it? The shell assignments should always have the form `var=rhs`. Even if `rhs` is empty, it should still generate an empty string as a RHS.

As far as I quickly checked the code, the RHS seems ensured to be not None. In this PR, I attempt to assert it never happens and see if the assertion passes the CI.