### PR TITLE
[core/state] Do not initialize a sparse array with a long `List[str]`

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -288,7 +288,7 @@ def _ReconcileTypes(rval, flag_a, flag_A, blame_word):
                 # mycpp limitation: NewDict() needs to be typed
                 tmp = NewDict()  # type: Dict[str, str]
                 return value.BashAssoc(tmp)
-                #return bash_impl.BashArray_FromList([])
+                #return bash_impl.BashArray_New()
 
         if rval.tag() != value_e.BashAssoc:
             e_usage("Got -A but RHS isn't an associative array",
@@ -321,7 +321,7 @@ class Readonly(vm._AssignBuiltin):
         for pair in cmd_val.pairs:
             if pair.rval is None:
                 if arg.a:
-                    rval = bash_impl.BashArray_FromList([])  # type: value_t
+                    rval = bash_impl.BashArray_New()  # type: value_t
                 elif arg.A:
                     # mycpp limitation: NewDict() needs to be typed
                     tmp = NewDict()  # type: Dict[str, str]
@@ -456,7 +456,7 @@ class NewVar(vm._AssignBuiltin):
                 if arg.a:
                     if old_val.tag() not in (value_e.InternalStringArray,
                                              value_e.BashArray):
-                        rval = bash_impl.BashArray_FromList([])
+                        rval = bash_impl.BashArray_New()
                 elif arg.A:
                     if old_val.tag() != value_e.BashAssoc:
                         # mycpp limitation: NewDict() needs to be typed

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -347,9 +347,15 @@ def BashAssoc_ToStrForShellPrint(assoc_val):
 # BashArray come here.
 
 
+def BashArray_New():
+    # type: () -> value.BashArray
+    d = {}  # type: Dict[mops.BigInt, str]
+    max_index = mops.MINUS_ONE  # max index for empty array
+    return value.BashArray(d, max_index)
+
+
 def BashArray_FromList(strs):
     # type: (List[str]) -> value.BashArray
-
     d = {}  # type: Dict[mops.BigInt, str]
     max_index = mops.MINUS_ONE  # max index for empty array
     for s in strs:

--- a/spec/ble-sparse.test.sh
+++ b/spec/ble-sparse.test.sh
@@ -1181,3 +1181,23 @@ json write (crash_dump.var_stack[0].a)
 
 ## N-I bash/mksh STDOUT:
 ## END
+
+
+#### Regression: a[-1]=1
+case $SH in mksh) exit ;; esac
+
+a[-1]=1
+
+## status: 1
+## STDOUT:
+## END
+## STDERR:
+  a[-1]=1
+  ^~
+[ stdin ]:3: fatal: Index %d is out of bounds for array of length 0
+## END
+## OK bash STDERR:
+bash: line 3: a[-1]: bad array subscript
+## END
+## N-I mksh status: 0
+## N-I mksh stderr-json: ""


### PR DESCRIPTION
Fixes #2263.

This fixes an issue of #2263. This also fixes another issue https://github.com/oils-for-unix/oils/issues/2263#issuecomment-2677382000. In the previous versions, `unset[-1]=1` has created `unset=(1)` in the Python version and has core-dumped in the C++ version.


```console
$ bash -c 'unset[-1]=1; declare -p unset'
bash: line 1: unset[-1]: bad array subscript
$ bin/osh -c 'unset[-1]=1; declare -p unset'
declare -a unset=(1)
$ osh-0.27.0 -c 'unset[-1]=1; declare -p unset'  # 0.27.0 C++ version
Segmentation fault         (core dumped) osh-0.27.0 -c 'unset[-1]=1; declare -p unset'
```

The last commit 069162fd6 adds a spec test for the above bug.

This PR contains another commit a271b53c61b69413d53e136511131f13ccc4a413 to refactor the creation of a new sparse array. We've been passed an empty `List[str]` to `BashArray_FromList(list)`, but it is unnecessary to generate any list for an empty new sparse array. This commit adds a new function `BashArray_New()`.
