### PR TITLE
[osh/word_parse] Perform tilde expansion on `rhs` of `dict=([key]=rhs)`

### DIFF
--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -1666,6 +1666,7 @@ class WordParser(WordEmitter):
         # If the first one is a key/value pair, then the rest are assumed to be.
         pair = word_.DetectAssocPair(words[0])
         if pair:
+            word_.TildeDetectAssign(pair.value)  # pair.value is modified
             pairs.append(pair)
 
             n = len(words)
@@ -1675,6 +1676,7 @@ class WordParser(WordEmitter):
                 if not pair:
                     p_die("Expected associative array pair", loc.Word(w2))
 
+                word_.TildeDetectAssign(pair.value)  # pair.value is modified
                 pairs.append(pair)
 
             # invariant List?

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -270,6 +270,7 @@ echo "${a[@]}"
 ## N-I mksh/ash STDOUT:
 ## END
 
+
 #### shopt -u expand_aliases and eval
 case $SH in zsh|mksh|ash) exit ;; esac
 
@@ -289,3 +290,26 @@ hello
 ## N-I zsh/mksh/ash STDOUT:
 ## END
 
+
+#### Tilde expansions in RHS of designated array initialization
+case $SH in zsh|mksh|ash) exit ;; esac
+
+HOME=/home/user
+declare -A a
+declare -A a=(['home']=~ ['hello']=~:~:~)
+echo "${a['home']}"
+echo "${a['hello']}"
+
+## STDOUT:
+/home/user
+/home/user:/home/user:/home/user
+## END
+
+# Note: bash-5.2 has a bug that the tilde doesn't expand on the right hand side
+# of [key]=value.  This problem doesn't happen in bash-3.1..5.1 and bash-5.3.
+## BUG bash STDOUT:
+~
+~:~:~
+## END
+
+## N-I zsh/mksh/ash stdout-json: ""


### PR DESCRIPTION
The right-hand side of `[k]=rhs` in the list assignment `a=([k]=v)` is subject to the tilde expansion. However, the current `master` doesn't perform it:

```console
$ bash -c "declare -A a=([k]=~); echo \"\${a['k']}\""
/home/murase
$ bin/osh -c "declare -A a=([k]=~); echo \"\${a['k']}\""
~
```

### Note: Bash 5.2 has a bug

It should be noted that Bash 5.2 has a similar bug. It is fixed in Bash 5.3.

```console
$ bash-5.1 -c "declare -A a=([k]=~); echo \"\${a['k']}\""
/home/murase
$ bash-5.2 -c "declare -A a=([k]=~); echo \"\${a['k']}\""
~
$ bash-5.3 -c "declare -A a=([k]=~); echo \"\${a['k']}\""
/home/murase
```
