### PR TITLE
[builtin/assign_osh] Do not remove existing arrays with `readonly -a/-A`

### DIFF
--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -672,6 +672,28 @@ dict:3
 ## N-I dash/mksh status: 99
 ## N-I dash/mksh stdout-json: ""
 
+#### "readonly -a arr" and "readonly -A dict" should not not remove existing arrays
+# mksh's readonly does not support the -a option.
+# dash/mksh does not support associative arrays.
+case $SH in (dash|mksh) exit 99;; esac
+
+declare -a arr
+arr=(foo bar baz)
+declare -A dict
+dict['foo']=hello
+dict['bar']=oil
+dict['baz']=world
+
+readonly -a arr
+echo arr:${#arr[@]}
+readonly -A dict
+echo dict:${#dict[@]}
+## STDOUT:
+arr:3
+dict:3
+## END
+## N-I dash/mksh status: 99
+## N-I dash/mksh stdout-json: ""
 
 #### "declare -a arr" and "readonly -a a" creates an empty array (OSH)
 case $SH in (dash|mksh) exit 99;; esac # dash/mksh does not support associative arrays


### PR DESCRIPTION
In the current `master`, `readonly -a a` and `readonly -A a` remove existing indexed and associative arrays, respectively. See the following example:

```console
$ bash -c 'a=(1 2 3); readonly -a a; declare -p a'
declare -ar a=([0]="1" [1]="2" [2]="3")
$ osh -c 'a=(1 2 3); readonly -a a; declare -a a'
declare -ra a=()
```

This PR fixes the above behavior by initializing an empty array only when an existing value has a different type from the one expected by `-a` or `-A`. This behavioral change is similar to the one for the `declare` builtin introduced in #731.

Actually, this behavior of removing the existing arrays has been hidden under another bug fixed in #2265. Now #2265 was merged, and this problem has been revealed.

----

This patch moves the adjustment of the value into the function `_ReconcileTypes`, which is shared by `readonly` and `declare`.
