### PR TITLE
[osh/sh_expr_eval] Check `readonly` before modifying the object

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -204,7 +204,11 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags):
     """
     lval = LeftName(pair.var_name, pair.blame_word)
     if pair.plus_eq:
-        old_val = sh_expr_eval.OldValue(lval, mem, None)  # ignore set -u
+        old_val = sh_expr_eval.OldValue(
+            lval,
+            mem,
+            None,  # ignore set -u
+            pair.blame_word)
         # When 'export e+=', then rval is value.Str('')
         # When 'export foo', the pair.plus_eq flag is false.
         assert rval is not None

--- a/core/state.py
+++ b/core/state.py
@@ -2111,14 +2111,6 @@ class Mem(object):
 
     def GetValue(self, name, which_scopes=scope_e.Shopt):
         # type: (str, scope_t) -> value_t
-        return self._GetValue(name, which_scopes, False, loc.Missing)
-
-    def GetValueForRewrite(self, name, blame_loc, which_scopes=scope_e.Shopt):
-        # type: (str, loc_t, scope_t) -> value_t
-        return self._GetValue(name, which_scopes, True, blame_loc)
-
-    def _GetValue(self, name, which_scopes, to_write, blame_loc):
-        # type: (str, scope_t, bool, loc_t) -> value_t
         """Used by the WordEvaluator, ArithEvaluator, ExprEvaluator, etc."""
         assert isinstance(name, str), name
 
@@ -2288,9 +2280,6 @@ class Mem(object):
                 #    We still need a ref_trail to detect cycles.
                 cell, _, _ = self._ResolveNameOrRef(name, which_scopes)
                 if cell:
-                    if to_write and cell.readonly:
-                        e_die("Can't assign to readonly variable %r" % name,
-                              blame_loc)
                     return cell.val
 
                 builtin_val = self.builtins.get(name)
@@ -2316,6 +2305,17 @@ class Mem(object):
             which_scopes = self.ScopesForReading()
 
         cell, _ = self._ResolveNameOnly(name, which_scopes)
+        return cell
+
+    def GetCellDeref(self, name, which_scopes=scope_e.Shopt):
+        # type: (str, scope_t) -> Cell
+        """Get both the value and flags. Unlike GetCell, this resolves
+        name references.
+        """
+        if which_scopes == scope_e.Shopt:
+            which_scopes = self.ScopesForReading()
+
+        cell, _, _ = self._ResolveNameOrRef(name, which_scopes)
         return cell
 
     def Unset(self, lval, which_scopes):

--- a/core/state.py
+++ b/core/state.py
@@ -2111,6 +2111,14 @@ class Mem(object):
 
     def GetValue(self, name, which_scopes=scope_e.Shopt):
         # type: (str, scope_t) -> value_t
+        return self._GetValue(name, which_scopes, False, loc.Missing)
+
+    def GetValueForRewrite(self, name, blame_loc, which_scopes=scope_e.Shopt):
+        # type: (str, loc_t, scope_t) -> value_t
+        return self._GetValue(name, which_scopes, True, blame_loc)
+
+    def _GetValue(self, name, which_scopes, to_write, blame_loc):
+        # type: (str, scope_t, bool, loc_t) -> value_t
         """Used by the WordEvaluator, ArithEvaluator, ExprEvaluator, etc."""
         assert isinstance(name, str), name
 
@@ -2280,6 +2288,9 @@ class Mem(object):
                 #    We still need a ref_trail to detect cycles.
                 cell, _, _ = self._ResolveNameOrRef(name, which_scopes)
                 if cell:
+                    if to_write and cell.readonly:
+                        e_die("Can't assign to readonly variable %r" % name,
+                              blame_loc)
                     return cell.val
 
                 builtin_val = self.builtins.get(name)

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -984,7 +984,8 @@ class CommandEvaluator(object):
 
                 lval = self.arith_ev.EvalShellLhs(pair.lhs, which_scopes)
                 # do not respect set -u
-                old_val = sh_expr_eval.OldValue(lval, self.mem, None)
+                old_val = sh_expr_eval.OldValue(lval, self.mem, None,
+                                                node.left)
 
                 val = PlusEquals(old_val, rhs)
 

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -127,7 +127,7 @@ def OldValue(lval, mem, exec_opts, blame_loc):
         else:
             raise AssertionError()
 
-    val = mem.GetValue(var_name)
+    val = mem.GetValueForRewrite(var_name, blame_loc)
     if exec_opts and exec_opts.nounset() and val.tag() == value_e.Undef:
         e_die('Undefined variable %r' % var_name, blame_loc)
 

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -92,8 +92,8 @@ _ = log
 #
 
 
-def OldValue(lval, mem, exec_opts):
-    # type: (sh_lvalue_t, state.Mem, Optional[optview.Exec]) -> value_t
+def OldValue(lval, mem, exec_opts, blame_loc):
+    # type: (sh_lvalue_t, state.Mem, Optional[optview.Exec], loc_t) -> value_t
     """Look up for augmented assignment.
 
     For s+=val and (( i += 1 ))
@@ -129,7 +129,7 @@ def OldValue(lval, mem, exec_opts):
 
     val = mem.GetValue(var_name)
     if exec_opts and exec_opts.nounset() and val.tag() == value_e.Undef:
-        e_die('Undefined variable %r' % var_name)  # TODO: location info
+        e_die('Undefined variable %r' % var_name, blame_loc)
 
     UP_val = val
     with tagswitch(lval) as case:
@@ -512,7 +512,8 @@ class ArithEvaluator(object):
         """ For x = y  and   x += y  and  ++x """
 
         lval = self.EvalArithLhs(node)
-        val = OldValue(lval, self.mem, self.exec_opts)
+        val = OldValue(lval, self.mem, self.exec_opts,
+                       location.TokenForArith(node))
 
         # BASH_LINENO, arr (array name without strict_array), etc.
         if (val.tag() in (value_e.InternalStringArray, value_e.BashAssoc,

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -127,7 +127,14 @@ def OldValue(lval, mem, exec_opts, blame_loc):
         else:
             raise AssertionError()
 
-    val = mem.GetValueForRewrite(var_name, blame_loc)
+    cell = mem.GetCellDeref(var_name)
+    if cell is not None:
+        if cell.readonly:
+            e_die("Can't assign to readonly variable %r" % var_name, blame_loc)
+        val = cell.val
+    else:
+        val = value.Undef
+
     if exec_opts and exec_opts.nounset() and val.tag() == value_e.Undef:
         e_die('Undefined variable %r' % var_name, blame_loc)
 

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -738,8 +738,11 @@ a=(1 2 3)
 readonly -a a
 eval 'a+=(4)'
 argv.py "${a[@]}"
+eval 'declare -n r=a; r+=(4)'
+argv.py "${a[@]}"
 
 ## STDOUT:
+['1', '2', '3']
 ['1', '2', '3']
 ## END
 ## OK mksh status: 1

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -730,3 +730,19 @@ typeset -Ar dict2
 ## END
 ## N-I dash/mksh status: 99
 ## N-I dash/mksh stdout-json: ""
+
+#### readonly array should not be modified by a+=(1)
+case $SH in (dash) exit 99;; esac # dash/mksh does not support associative arrays
+
+a=(1 2 3)
+readonly -a a
+eval 'a+=(4)'
+argv.py "${a[@]}"
+
+## STDOUT:
+['1', '2', '3']
+## END
+## OK mksh status: 1
+## OK mksh stdout-json: ""
+## N-I dash status: 99
+## N-I dash stdout-json: ""


### PR DESCRIPTION
In the current `osh`, readonly arrays can be modified using `a+=(...)`:

```console
$ bash -c 'readonly -a a=(1 2 3); declare -p a; eval "a+=(4)" 2>/dev/null; declare -p a'
declare -ar a=([0]="1" [1]="2" [2]="3")
declare -ar a=([0]="1" [1]="2" [2]="3")
$ osh-0.27.0 -c 'readonly -a a=(1 2 3); declare -p a; eval "a+=(4)" 2>/dev/null; declare -p a'
declare -ra a=(1 2 3)
declare -ra a=(1 2 3 4)
```

----

- The first commit 808a628c8 makes `sh_expr_eval.OldValue` receive a new argument `blame_loc` and resolves the following TODO:

https://github.com/oils-for-unix/oils/blob/a3b3a609bec59b159ab4f90c432613fdb7d1bc27/osh/sh_expr_eval.py#L132

- The second commit 6bd51d50c fixes the issue that readonly arrays can be modified by `a+=(...)`.