### PR TITLE
[osh/word_] Disallow `BashAssocLiteral` in temporary environment

### DIFF
--- a/osh/word_.py
+++ b/osh/word_.py
@@ -398,7 +398,8 @@ def HasArrayPart(w):
     # type: (CompoundWord) -> bool
     """Used in cmd_parse."""
     for part in w.parts:
-        if part.tag() == word_part_e.ShArrayLiteral:
+        if part.tag() in (word_part_e.ShArrayLiteral,
+                          word_part_e.BashAssocLiteral):
             return True
     return False
 

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -281,6 +281,14 @@ A=a B=(b b) printenv.py A B
 ## OK bash status: 0
 ## OK mksh status: 1
 
+#### Associative arrays can't be used as env bindings either
+A=a B=([k]=v) printenv.py A B
+## status: 2
+## stdout-json: ""
+## OK bash stdout-json: "a\n([k]=v)\n"
+## OK bash status: 0
+## OK mksh status: 1
+
 #### Set element
 a=(1 '2 3')
 a[0]=9


### PR DESCRIPTION
I think this should anyway be fixed when InitializerList is introduced, but I'd like to confirm the intended behavior. In the current osh, arrays of the form `(1 2 3)` (`ShArrayLiteral`) cannot be specified in tmpenv, but the form `([k]=v)` (`BashAssocLiteral`) can be specified:

```console
$ osh-0.27.0 -c 'A=(a a) declare -p A'
  A=(a a) declare -p A
  ^~
[ -c flag ]:1: Environment bindings can't contain array literals
$ osh-0.27.0 -c 'A=([a]=a) declare -p A'
declare -A A=(['a']=a)
```

I think `BashAssocLiteral` should also be rejected for consistency.