### PR TITLE
[osh] Implement InitializerList for `a=(v [k]=v [k]+=v)`

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -221,6 +221,14 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags, arith_ev,
             pair.blame_word)
         initializer = cast(value.InitializerList, rval)
 
+        # OSH compatibility: "declare -A assoc=(1 2)" is a usage
+        # error.  This code will soon be removed when the
+        # initialization of the form "assoc=(key value)" is supported.
+        if (flag_A and len(initializer.assigns) > 0 and
+                initializer.assigns[0].key is None):
+            e_usage("Can't initialize assoc array with indexed array",
+                    pair.blame_word)
+
         val = old_val
         if flag_a:
             if old_val.tag() == value_e.BashAssoc:
@@ -251,7 +259,8 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags, arith_ev,
                     "Can't convert type %s into BashAssoc" %
                     ui.ValType(old_val), pair.blame_word)
 
-        val = cmd_eval.ListInitializeTarget(val, pair.plus_eq, pair.blame_word)
+        val = cmd_eval.ListInitializeTarget(val, initializer, pair.plus_eq,
+                                            pair.blame_word)
     elif pair.plus_eq:
         old_val = sh_expr_eval.OldValue(
             lval,

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -284,6 +284,15 @@ def BashAssoc_New():
     return value.BashAssoc(d)
 
 
+def BashAssoc_Copy(val):
+    # type: (value.BashAssoc) -> value.BashAssoc
+    # mycpp limitation: NewDict() needs to be typed
+    d = mylib.NewDict()  # type: Dict[str, str]
+    for key in val.d:
+        d[key] = val.d[key]
+    return value.BashAssoc(d)
+
+
 def BashAssoc_ListInitialize(val, initializer, has_plus, blame_loc):
     # type: (value.BashAssoc, value.InitializerList, bool, loc_t) -> None
 
@@ -396,6 +405,14 @@ def BashArray_New():
     d = {}  # type: Dict[mops.BigInt, str]
     max_index = mops.MINUS_ONE  # max index for empty array
     return value.BashArray(d, max_index)
+
+
+def BashArray_Copy(val):
+    # type: (value.BashArray) -> value.BashArray
+    d = {}  # type: Dict[mops.BigInt, str]
+    for index in val.d:
+        d[index] = val.d[index]
+    return value.BashArray(d, val.max_index)
 
 
 def BashArray_FromList(strs):

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -2,7 +2,9 @@
 
 from _devbuild.gen.runtime_asdl import error_code_e, error_code_t
 from _devbuild.gen.value_asdl import value
+from _devbuild.gen.syntax_asdl import loc_t
 
+from core.error import e_die
 from data_lang import j8_lite
 from mycpp import mops
 from mycpp import mylib
@@ -28,6 +30,21 @@ def BigInt_GreaterEq(a, b):
 def BigInt_LessEq(a, b):
     # type: (mops.BigInt, mops.BigInt) -> bool
     return not mops.Greater(a, b)
+
+
+class ArrayIndexEvaluator(object):
+    """Interface class for implementing the evaluation of array indices in
+    initializer-list items of the form [i]=1."""
+
+    def __init__(self):
+        # type: () -> None
+        """Empty constructor for mycpp."""
+        pass
+
+    def StringToBigInt(self, s, blame_loc):
+        # type: (str, loc_t) -> mops.BigInt
+        """Returns an array index obtained by evaluating the specified string."""
+        raise NotImplementedError()
 
 
 #------------------------------------------------------------------------------
@@ -267,6 +284,26 @@ def BashAssoc_New():
     return value.BashAssoc(d)
 
 
+def BashAssoc_ListInitialize(val, initializer, has_plus, blame_loc):
+    # type: (value.BashAssoc, value.InitializerList, bool, loc_t) -> None
+
+    if not has_plus:
+        val.d.clear()
+
+    for triplet in initializer.assigns:
+        if triplet.key is None:
+            e_die(
+                "Key is missing. BashAssoc requires a key for %r" %
+                triplet.rval, blame_loc)
+
+        s = triplet.rval
+        if triplet.plus_eq:
+            old_s = val.d.get(triplet.key)
+            if old_s is not None:
+                s = old_s + s
+        val.d[triplet.key] = s
+
+
 def BashAssoc_IsEmpty(assoc_val):
     # type: (value.BashAssoc) -> bool
     return len(assoc_val.d) == 0
@@ -371,6 +408,30 @@ def BashArray_FromList(strs):
             d[max_index] = s
 
     return value.BashArray(d, max_index)
+
+
+def BashArray_ListInitialize(val, initializer, has_plus, blame_loc, arith_ev):
+    # type: (value.BashArray, value.InitializerList, bool, loc_t, ArrayIndexEvaluator) -> None
+    if not has_plus:
+        val.d.clear()
+        val.max_index = mops.MINUS_ONE
+
+    array_index = val.max_index
+    for triplet in initializer.assigns:
+        if triplet.key is not None:
+            array_index = arith_ev.StringToBigInt(triplet.key, blame_loc)
+        else:
+            array_index = mops.Add(array_index, mops.ONE)
+
+        s = triplet.rval
+        if triplet.plus_eq:
+            old_s = val.d.get(array_index)
+            if old_s is not None:
+                s = old_s + s
+
+        val.d[array_index] = s
+        if BigInt_Greater(array_index, val.max_index):
+            val.max_index = array_index
 
 
 def BashArray_IsEmpty(sparse_val):

--- a/core/bash_impl.py
+++ b/core/bash_impl.py
@@ -583,3 +583,26 @@ def BashArray_ToStrForShellPrint(sparse_val):
 
         body.append(j8_lite.MaybeShellEncode(sparse_val.d[index]))
     return "(%s)" % ''.join(body)
+
+
+#------------------------------------------------------------------------------
+# InitializerList operations depending on its internal representation come
+# here.
+
+
+def InitializerList_ToStrForShellPrint(val):
+    # type: (value.InitializerList) -> str
+    body = []  # type: List[str]
+
+    for init in val.assigns:
+        if len(body) > 0:
+            body.append(" ")
+        if init.key is not None:
+            key = j8_lite.MaybeShellEncode(init.key)
+            if init.plus_eq:
+                body.extend(["[", key, "]+="])
+            else:
+                body.extend(["[", key, "]="])
+        body.append(j8_lite.MaybeShellEncode(init.rval))
+
+    return "(%s)" % ''.join(body)

--- a/core/dev.py
+++ b/core/dev.py
@@ -225,6 +225,10 @@ def _PrintShValue(val, buf):
             val = cast(value.BashArray, UP_val)
             result = bash_impl.BashArray_ToStrForShellPrint(val)
 
+        elif case(value_e.InitializerList):
+            val = cast(value.InitializerList, UP_val)
+            result = bash_impl.InitializerList_ToStrForShellPrint(val)
+
     buf.write(result)
 
 

--- a/core/shell.py
+++ b/core/shell.py
@@ -211,19 +211,20 @@ def InitAssignmentBuiltins(
         mem,  # type: state.Mem
         procs,  # type: state.Procs
         exec_opts,  # type: optview.Exec
+        arith_ev,  # type: sh_expr_eval.ArithEvaluator
         errfmt,  # type: ui.ErrorFormatter
 ):
     # type: (...) -> Dict[int, vm._AssignBuiltin]
 
     assign_b = {}  # type: Dict[int, vm._AssignBuiltin]
 
-    new_var = assign_osh.NewVar(mem, procs, exec_opts, errfmt)
+    new_var = assign_osh.NewVar(mem, procs, exec_opts, arith_ev, errfmt)
     assign_b[builtin_i.declare] = new_var
     assign_b[builtin_i.typeset] = new_var
     assign_b[builtin_i.local] = new_var
 
-    assign_b[builtin_i.export_] = assign_osh.Export(mem, errfmt)
-    assign_b[builtin_i.readonly] = assign_osh.Readonly(mem, errfmt)
+    assign_b[builtin_i.export_] = assign_osh.Export(mem, arith_ev, errfmt)
+    assign_b[builtin_i.readonly] = assign_osh.Readonly(mem, arith_ev, errfmt)
 
     return assign_b
 
@@ -506,7 +507,7 @@ def Main(
     word_ev = word_eval.NormalWordEvaluator(mem, exec_opts, mutable_opts,
                                             tilde_ev, splitter, errfmt)
 
-    assign_b = InitAssignmentBuiltins(mem, procs, exec_opts, errfmt)
+    assign_b = InitAssignmentBuiltins(mem, procs, exec_opts, arith_ev, errfmt)
     cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs, assign_b,
                                        arena, cmd_deps, trap_state,
                                        signal_safe)

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -225,13 +225,15 @@ def InitCommandEvaluator(parse_ctx=None,
 
     readline = None  # simulate not having it
 
-    new_var = assign_osh.NewVar(mem, procs, exec_opts, errfmt)
+    arith_ev = sh_expr_eval.ArithEvaluator(mem, exec_opts, mutable_opts,
+                                           parse_ctx, errfmt)
+    new_var = assign_osh.NewVar(mem, procs, exec_opts, arith_ev, errfmt)
     assign_builtins = {
         builtin_i.declare: new_var,
         builtin_i.typeset: new_var,
         builtin_i.local: new_var,
-        builtin_i.export_: assign_osh.Export(mem, errfmt),
-        builtin_i.readonly: assign_osh.Readonly(mem, errfmt),
+        builtin_i.export_: assign_osh.Export(mem, arith_ev, errfmt),
+        builtin_i.readonly: assign_osh.Readonly(mem, arith_ev, errfmt),
     }
     builtins = {  # Lookup
         builtin_i.echo: io_osh.Echo(exec_opts),
@@ -265,8 +267,6 @@ def InitCommandEvaluator(parse_ctx=None,
 
     splitter = split.SplitContext(mem)
 
-    arith_ev = sh_expr_eval.ArithEvaluator(mem, exec_opts, mutable_opts,
-                                           parse_ctx, errfmt)
     bool_ev = sh_expr_eval.BoolEvaluator(mem, exec_opts, mutable_opts,
                                          parse_ctx, errfmt)
     expr_ev = expr_eval.ExprEvaluator(mem, mutable_opts, methods, splitter,

--- a/core/value.asdl
+++ b/core/value.asdl
@@ -27,6 +27,8 @@ module value
 
   IntBox = (int i)
 
+  InitializerValue = (str? key, str rval, bool plus_eq)
+
   ProcDefaults = (
     List[value]? for_word,  # all of them are value.Str
     List[value]? for_typed,
@@ -101,6 +103,8 @@ module value
   | Undef
 
   | Str(str s)
+
+  | InitializerList(List[InitializerValue] assigns)
 
     # "holes" in the array are represented by None
   | InternalStringArray(List[str] strs)

--- a/doc/known-differences.md
+++ b/doc/known-differences.md
@@ -341,8 +341,7 @@ Here is how you can create arrays in OSH, in a bash-compatible way:
     local -a indexed=(foo bar)            # -a is redundant
     echo ${indexed[1]}                    # bar
 
-    local assoc=(['one']=1 ['two']=2)
-    local -A assoc=(['one']=1 ['two']=2)  # -A is redundant
+    local -A assoc=(['one']=1 ['two']=2)  # -A is necessary
     echo ${assoc['one']}                  # 1
 
 In bash, the distinction between the two is blurry, with cases like this:
@@ -350,7 +349,8 @@ In bash, the distinction between the two is blurry, with cases like this:
     local -A x=(foo bar)                  # -A disagrees with literal
     local -a y=(['one']=1 ['two']=2)      # -a disagrees with literal
 
-These are disallowed in OSH.
+The latter was disallowed in OSH, but `osh >= 0.28.0` has started to support
+it.
 
 Notes:
 

--- a/doc/quirks.md
+++ b/doc/quirks.md
@@ -17,29 +17,53 @@ Related: [Known Differences](known-differences.html).
 ### The meaning of `()` on the RHS
 
 In Oils, **values** are tagged with types like `Str` and `AssocArray`, as
-opposed to the *locations* of values (cells).
+opposed to the *locations* of values (cells).  The construct `()` on the RHS
+generates an instance of a distinct type `InitializerList`, which modifies the
+content of the LHS that it is assigned to.
 
 This statement binds an empty indexed array to the name `x`:
 
     x=()  # indexed by integers
 
-**Quirk**: When it's clear from the context, `()` means an empty
-**associative** array:
+This clears the content of the associative array.
 
     declare -A x=()  # indexed by strings, because of -A
 
-This only applies when the array is empty.  Otherwise the type is determined by
-the literal:
+These assign elements.
+
+    declare -a x=(one two)  # set elements
+    declare -a x=(['k']=v)  # set an element to the index $((k))
+    declare -A x=(['k']=v)  # set an element to the key 'k'
+
+This is not supported:
+
+    declare -A x=(key value)  # Error in osh
+
+When the variable does not exist and a type is not specified, the assignment
+creates an indexed array and applies the `InitializerList` to the created
+array.
+
+    declare x=(one two)  # creates an indexed array
+    declare x=(['k']=v)  # creates an indexed array
+
+**Quirk (osh <= 0.27.0)**: The construct `()` had an ambiguous type, which was
+either `BashArray` or `BashAssoc` depending on its content and the context.
+When it's clear from the context, `()` meant an empty **associative** array:
+
+    declare -A x=()  # indexed by strings, because of -A
+
+This was only applied when the array is empty.  Otherwise the type was
+determined by the literal:
 
     declare x=(one two)  # indexed array
     declare x=(['k']=v)  # associative array
 
-Redundant but OK:
+These were redundant but OK:
 
     declare -a x=(one two)  # indexed array
     declare -A x=(['k']=v)  # associative array
 
-Errors:
+These produced errors:
 
     declare -A x=(one two)  # inconsistent
     declare -a x=(['k']=v)  # inconsistent

--- a/doc/ref/chap-osh-assign.md
+++ b/doc/ref/chap-osh-assign.md
@@ -26,18 +26,194 @@ This chapter describes OSH assignment, which looks like `x=value`.
 
 ### sh-append
 
-## Compound Data
+## Compound Assignment
+
+### sh-init-list
+
+Indexed and associative arrays may be initialized by an assignment of an
+initializer list.
+
+    arr=(1 2 3 4)
+    dict=([apple]=red [banana]=yellow [orange]=orange)
+
+An initializer list does *NOT* provide a new value that will be assigned to the
+LHS of the assignment.  The initializer list is rather considered *a set of
+instructions to modify the existing value of the LHS*.
+
+When the assignment is performed with `=`, the content of the LHS value is
+cleared before starting the modifications.  When the assignment is performed
+with `+=`, the modifications are applied to the existing content of the LHS
+value.
+
+An initializer list has the following form: `(<words>...)`, where each word has
+one of the following forms:
+
+- `[<key>]=<value>` ... This assigns `<value>` to an element of the LHS
+  specified by `<key>`.  The `<value>` is not subject to word splitting and
+  pathname expansions as if it is the RHS of an assignment.
+- `[<key>]+=<value>` ... This appends `<value>` to an element of the LHS
+  specified by `<key>`.  If the corresponding element does not exist, it simply
+  assigns `<value>` to a new element associated with `<key>`.  The `<value>` is
+  not subject to word splitting and pathname expansions.
+- `<value>` ... If the word does not have the above two forms, it is considered
+  a normal word.  In this case, this assigns `<value>` to the *next* element,
+  where the next element is determined by the LHS.  Unlike the previous two
+  forms, the `<value>` is subject to word splitting and pathname expansions as
+  if it is a normal argument to a command.
+
+The above three forms can be mixed within one initializer list, though there
+may be additional limitations depending on the type of the LHS of the
+assignment.
+
+The details of the actual modification depends on the type of the LHS.  The
+assignment of an initializer list can be understood in two phases: the type of
+the LHS is first adjusted, and then the modifications to the LHS variable are
+applied.
+
+In the first phase, the type adjustment is performed in the following way:
+
+- When the LHS variable is unset, the assignment creates an empty indexed array
+  (BashArray) and apply the initializer list to the created array.  If the
+  assignment is performed through an assignment builtin and flag `-A` is
+  supplied to the builtin, an empty associative array (BashAssoc) is created
+  instead of an empty BashArray.
+- When the LHS is a scalar string, the assignment creates a BashArray with one
+  element, where the original value is stored at index `0`.  If the assignment
+  is performed through an assignment builtin and flag `-A` is supplied to the
+  builtin, the assignment creates a BashAssoc with one element, where the
+  original value is stored at key `"0"` instead of a BashArray.  If the
+  assignment operator is `+=`, OSH issues an error "Can't append an array to
+  string", while Bash is permissive.
+- When the LHS is an indexed or associative arrays, the initializer list is
+  applied to the original array following [sh-array](#sh-array) (for an indexed
+  array) or [sh-assoc](#sh-assoc) (for an associative array).  If the
+  assignemnt is performed through an assignment builtin and mismatching flag
+  (i.e., `-A` and `-a` for BashArray and BashAssoc, respectively) is supplied,
+  OSH discards the original array and creates a new empty BashArray (for flag
+  `-a`) or BashAssoc (for flag `-A`), while Bash issues an error preserving the
+  original array.
+- Otherwise, it is an error.
+
+These rules are summarized in the following table.
+
+<table>
+
+- thead
+  - Original LHS type
+  - Flags
+  - Result
+  - Remarks
+- tr
+  - Undef
+  - (none)
+  - an empty BashArray
+  - <!-- empty -->
+- tr
+  - <!-- empty -->
+  - `-a`
+  - an empty BashArray
+  - <!-- empty -->
+- tr
+  - <!-- empty -->
+  - `-A`
+  - an empty BashArray
+  - <!-- empty -->
+- tr
+  - Str
+  - (none)
+  - BashArray with one element, with the original string at index 0
+  - OSH does not accept `+=`, so the element is never used
+- tr
+  - <!-- empty -->
+  - `-a`
+  - BashArray with one element, with the original string at index 0
+  - OSH does not accept `+=`, so the element is never used
+- tr
+  - <!-- empty -->
+  - `-A`
+  - BashAssoc with one element, with the original string at key `"0"`
+  - OSH does not accept `+=`, so the element is never used
+- tr
+  - <!-- empty -->
+  - `-A`
+  - an empty BashArray
+  - <!-- empty -->
+- tr
+  - BashArray
+  - (none)
+  - the original BashArray
+  - <!-- empty -->
+- tr
+  - <!-- empty -->
+  - `-a`
+  - the original BashArray
+  - <!-- empty -->
+- tr
+  - <!-- empty -->
+  - `-A`
+  - an empty BashAssoc
+  - Error in Bash
+- tr
+  - BashAssoc
+  - (none)
+  - the original BashAssoc
+  - <!-- empty -->
+- tr
+  - <!-- empty -->
+  - `-a`
+  - an empty BashArray
+  - Error in Bash
+- tr
+  - <!-- empty -->
+  - `-A`
+  - the original BashAssoc
+  - <!-- empty -->
+
+</table>
+
+In the second phase, the modifications are applied depending on the result of
+the first phase.  When the result is BashArray, see [sh-array](#sh-array).
+When the result is BashAssoc, see [sh-array](#sh-array).
 
 ### sh-array
 
-Array literals in shell accept any sequence of words, just like a command does:
+When an initializer list is assigned to [BashArray][], the values will be set
+to elements of the array.  For example, one may store any sequence of words,
+just like a command does:
 
     ls $mystr "$@" *.py
 
     # Put it in an array
     a=(ls $mystr "$@" *.py)
 
-Their type is [BashArray][].
+To explain the initialization/mutation in more detail, the array is first
+cleared if the assignment operator is `=`.  Then, an element of the array is
+modified for each item in the initializer list in order.  The index of the
+element to be modified is determined in the following way:
+
+- When the first initializer item does not have `[<key>]=` or `[<key>]+=`, the
+  index is the maximum existing index in the array plus one, or `0` if the
+  array is empty.
+- When the second or later initializer item does not have `[<key>]=` or
+  `[<key>]+=`, the index is larger by one than the one modified by the previous
+  initializer item.
+- When the initialier item has `[<key>]=` or `[<key>]+=`, an arithmetic
+  evaluation is applied to `<key>` to obtain the index in `BigInt`
+
+Here are examples:
+
+    declare -a a            # This creates an empty array (OSH)
+    declare -a a=()         # This creates an empty array
+    declare -a a=(1 2)      # This creates an array with two elements: (1 2)
+
+    k=10
+    declare -a a=([k]=v 2)  # This creates a sparse array with two elements,
+                            # ([10]=v [11]=2)
+
+    declare -a a+=(3 4)     # This appends two values to the existing array:
+                            # ([10]=v [11]=2 [12]=3 [13]=4)
+    declare -a a+=([k]=5 6) # This overwrites two elements in the existing
+                            # array: ([10]=5 [11]=6 [12]=3 [13]=4)
 
 In YSH, use a [list-literal][] to create a [List][] instance.
 
@@ -49,11 +225,34 @@ In YSH, use a [list-literal][] to create a [List][] instance.
 
 ### sh-assoc
 
-Associative arrays map strings to strings:
+When an initializer list is assigned to [BashAssoc][], an associative array
+mapping a string into another string, the values will be set to elements of the
+associative array.  For example, an associative array can be initialized in the
+following way:
 
     declare -A assoc=(['k']=v ['k2']=v2)
 
-Their type is [BashAssoc][].
+The initialization/mutation of BashAssoc is performed in a manner similar to
+BashArray.  The associative array is first cleared if the assignment operator
+is `=`.  Then, the modification of an element is performed for each initializer
+item in order.  An item in the initializer list must be in the forms
+`[<key>]=<value>` or `[<key>]=<value>`.  The element to be modified is
+specified by `<key>`.
+
+    declare -A a                # This creates an empty BashAssoc (OSH)
+    declare -A a=()             # This creates an empty BashAssoc
+    declare -A a=([a]=1 [b]=2)  # This creates a BashAssoc with two elements
+
+    declare -A a=(1 2)          # This is an error (OSH)
+
+    k=10
+    declare -A a=([k]=v)        # This creates a BashAssoc with one element,
+                                # (['k']=1).  Unlike BashArray, "k" is not
+                                # processed by arithmetic expansion.
+    declare -a a+=([a]=3 [b]=4) # This adds two elements to the existing array.
+                                # The result is ([a]=3 [b]=4 [k]=v)
+    declare -a a+=([k]=5)       # This overwrites an element in the existing
+                                # array. The result is ([a]=3 [b]=4 [k]=5).
 
 In YSH, use a [dict-literal][] to create a [Dict][] instance.
 

--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -29,7 +29,7 @@ These two types are for OSH code only.
 A bash array holds a sequence of strings.  Some entries may be unset, i.e.
 *not* an empty string.
 
-See [sh-array][] for details.  In YSH, prefer to use [List](#List) instances.
+See [sh-init-list][] and [sh-array][] for initialization/mutation of BashArray.  In YSH, prefer to use [List](#List) instances.
 
 [sh-array]: chap-osh-assign.html#sh-array
 
@@ -38,7 +38,7 @@ See [sh-array][] for details.  In YSH, prefer to use [List](#List) instances.
 
 A bash associative array is a mapping from strings to strings.
 
-See [sh-assoc][] for details.  In YSH, prefer to use [Dict](#Dict) instances.
+See [sh-init-list][] and [sh-assoc][] for initialization/mutation of BashArray.  In YSH, prefer to use [Dict](#Dict) instances.
 
 [sh-assoc]: chap-osh-assign.html#sh-assoc
 

--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -26,19 +26,21 @@ These two types are for OSH code only.
 
 ### BashArray
 
-A bash array holds a sequence of strings.  Some entries may be unset, i.e.
-*not* an empty string.
+A bash array holds a sequence of strings.  Some entries may be **unset** (not
+an empty string).
 
-See [sh-init-list][] and [sh-array][] for initialization/mutation of BashArray.  In YSH, prefer to use [List](#List) instances.
+See [sh-init-list][] and [sh-array][] for creation/mutation of BashArray.
+In YSH, prefer to use [List](#List) instances.
 
 [sh-array]: chap-osh-assign.html#sh-array
-
+[sh-init-list]: chap-osh-assign.html#sh-init-list
 
 ### BashAssoc
 
 A bash associative array is a mapping from strings to strings.
 
-See [sh-init-list][] and [sh-assoc][] for initialization/mutation of BashArray.  In YSH, prefer to use [Dict](#Dict) instances.
+See [sh-init-list][] and [sh-assoc][] for creation/mutation of BashAssoc.  In
+YSH, prefer to use [Dict](#Dict) instances.
 
 [sh-assoc]: chap-osh-assign.html#sh-assoc
 

--- a/doc/ref/toc-osh.md
+++ b/doc/ref/toc-osh.md
@@ -121,9 +121,9 @@ X [Unsupported]   enable
 </h2>
 
 ```chapter-links-osh-assign
-  [Literals]      sh-init-list  a=(v1 [i]=v2 [k]+=v3) a+=(v1 [i]=v2 [k]+=v3)
-                  sh-array      array=(a b c)   array[1]=B   "${a[@]}"
-                  sh-assoc      assoc=(['a']=1 ['b']=2)   assoc['x']=b
+  [Literals]      sh-init-list  a=(v1 [i]=v2 [k]+=v3)   a+=(v1 [i]=v2 [k]+=v3)
+                  sh-array      array[123]=v   "${array[@]}"
+                  sh-assoc      assoc['k']=v   "${assoc[@]}"   "${!assoc[@]}"  
   [Operators]     sh-assign     str='xyz'
                   sh-append     str+='abc'
   [Builtins]      local     readonly    export   unset   shift

--- a/doc/ref/toc-osh.md
+++ b/doc/ref/toc-osh.md
@@ -121,7 +121,8 @@ X [Unsupported]   enable
 </h2>
 
 ```chapter-links-osh-assign
-  [Literals]      sh-array      array=(a b c)   array[1]=B   "${a[@]}"
+  [Literals]      sh-init-list  a=(v1 [i]=v2 [k]+=v3) a+=(v1 [i]=v2 [k]+=v3)
+                  sh-array      array=(a b c)   array[1]=B   "${a[@]}"
                   sh-assoc      assoc=(['a']=1 ['b']=2)   assoc['x']=b
   [Operators]     sh-assign     str='xyz'
                   sh-append     str+='abc'

--- a/frontend/id_kind_def.py
+++ b/frontend/id_kind_def.py
@@ -484,7 +484,7 @@ def AddKinds(spec):
             'Subshell',  # )
             'ShFunction',  # )
             'CasePat',  # )
-            'ShArrayLiteral',  # )
+            'Initializer',  # )
             'ExtGlob',  # )
             'BashRegexGroup',  # )
             'BlockLiteral',  # } that matches &{ echo hi }

--- a/frontend/location.py
+++ b/frontend/location.py
@@ -29,7 +29,7 @@ from _devbuild.gen.syntax_asdl import (
     CompoundWord,
     Token,
     SimpleVarSub,
-    ShArrayLiteral,
+    YshArrayLiteral,
     SingleQuoted,
     DoubleQuoted,
     CommandSub,
@@ -217,8 +217,8 @@ def LeftTokenForWordPart(part):
     # type: (word_part_t) -> Optional[Token]
     UP_part = part
     with tagswitch(part) as case:
-        if case(word_part_e.ShArrayLiteral):
-            part = cast(ShArrayLiteral, UP_part)
+        if case(word_part_e.YshArrayLiteral):
+            part = cast(YshArrayLiteral, UP_part)
             return part.left
 
         elif case(word_part_e.InitializerLiteral):
@@ -290,8 +290,8 @@ def _RightTokenForWordPart(part):
     # type: (word_part_t) -> Token
     UP_part = part
     with tagswitch(part) as case:
-        if case(word_part_e.ShArrayLiteral):
-            part = cast(ShArrayLiteral, UP_part)
+        if case(word_part_e.YshArrayLiteral):
+            part = cast(YshArrayLiteral, UP_part)
             return part.right
 
         elif case(word_part_e.InitializerLiteral):
@@ -488,8 +488,8 @@ def TokenForExpr(node):
             node = cast(CommandSub, UP_node)
             return node.left_token
 
-        elif case(expr_e.ShArrayLiteral):
-            node = cast(ShArrayLiteral, UP_node)
+        elif case(expr_e.YshArrayLiteral):
+            node = cast(YshArrayLiteral, UP_node)
             return node.left
 
         elif case(expr_e.DoubleQuoted):

--- a/frontend/location.py
+++ b/frontend/location.py
@@ -221,8 +221,8 @@ def LeftTokenForWordPart(part):
             part = cast(ShArrayLiteral, UP_part)
             return part.left
 
-        elif case(word_part_e.BashAssocLiteral):
-            part = cast(word_part.BashAssocLiteral, UP_part)
+        elif case(word_part_e.InitializerLiteral):
+            part = cast(word_part.InitializerLiteral, UP_part)
             return part.left
 
         elif case(word_part_e.Literal):
@@ -294,8 +294,8 @@ def _RightTokenForWordPart(part):
             part = cast(ShArrayLiteral, UP_part)
             return part.right
 
-        elif case(word_part_e.BashAssocLiteral):
-            part = cast(word_part.BashAssocLiteral, UP_part)
+        elif case(word_part_e.InitializerLiteral):
+            part = cast(word_part.InitializerLiteral, UP_part)
             return part.right
 
         elif case(word_part_e.Literal):

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -195,11 +195,15 @@ module syntax
      Token right
   )
 
-  AssocPair = (CompoundWord key, CompoundWord value)
+  AssocPair = (CompoundWord key, CompoundWord value, bool has_plus)
+
+  InitializerWord =
+    ArrayWord(word w)
+  | AssocPair %AssocPair
 
   word_part = 
     ShArrayLiteral %ShArrayLiteral
-  | BashAssocLiteral(Token left, List[AssocPair] pairs, Token right)
+  | InitializerLiteral(Token left, List[InitializerWord] pairs, Token right)
   | Literal %Token
     # escaped case is separate so the evaluator doesn't have to check token ID
   | EscapedLiteral(Token token, str ch)

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -184,7 +184,7 @@ module syntax
 
   # - can contain word.BracedTree
   # - no 'Token right' for now, doesn't appear to be used
-  ShArrayLiteral = (Token left, List[word] words, Token right)
+  YshArrayLiteral = (Token left, List[word] words, Token right)
 
   # Unevaluated, typed arguments for func and proc.
   # Note that ...arg is expr.Spread.
@@ -202,7 +202,7 @@ module syntax
   | AssocPair %AssocPair
 
   word_part = 
-    ShArrayLiteral %ShArrayLiteral
+    YshArrayLiteral %YshArrayLiteral
   | InitializerLiteral(Token left, List[InitializerWord] pairs, Token right)
   | Literal %Token
     # escaped case is separate so the evaluator doesn't have to check token ID
@@ -251,7 +251,7 @@ module syntax
     # overhead and seems like overkill.  Note that DoubleQuoted can't
     # contain a SingleQuoted, etc. either.
   | Compound %CompoundWord
-    # For word sequences command.Simple, ShArrayLiteral, for_iter.Words
+    # For word sequences command.Simple, YshArrayLiteral, for_iter.Words
     # Could be its own type
   | BracedTree(List[word_part] parts)
     # For dynamic parsing of test aka [ - the string is already evaluated.
@@ -359,7 +359,7 @@ module syntax
   for_iter =
     Args                          # for x; do echo $x; done # implicit "$@"
   | Words(List[word] words)       # for x in 'foo' *.py { echo $x }
-                                  # like ShArrayLiteral, but no location for %(
+                                  # like YshArrayLiteral, but no location for %(
   | YshExpr(expr e, Token blame)  # for x in (mylist) { echo $x }
   #| Files(Token left, List[word] words)
                                   # for x in <> {
@@ -551,7 +551,7 @@ module syntax
   | Place(Token blame_tok, str var_name, place_op* ops)
 
     # :| one 'two' "$three" |
-  | ShArrayLiteral %ShArrayLiteral
+  | YshArrayLiteral %YshArrayLiteral
 
     # / d+ ; ignorecase; %python /
   | Eggex %Eggex

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -67,7 +67,7 @@ def _GetCastKind(module_path: str, cast_to_type: str) -> str:
     # Hack for Id.Expr_CastedDummy in expr_to_ast.py
     if 'expr_to_ast.py' in module_path:
         for name in (
-                'ShArrayLiteral',
+                'YshArrayLiteral',
                 'CommandSub',
                 'BracedVarSub',
                 'DoubleQuoted',
@@ -966,8 +966,8 @@ class Impl(_Shared):
     def oils_visit_call_expr(self, o: 'mypy.nodes.CallExpr') -> None:
         callee_name = o.callee.name
 
-        #    return cast(ShArrayLiteral, tok)
-        # -> return static_cast<ShArrayLiteral*>(tok)
+        #    return cast(YshArrayLiteral, tok)
+        # -> return static_cast<YshArrayLiteral*>(tok)
 
         # TODO: Consolidate this with AssignmentExpr logic.
         if callee_name == 'cast':

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -250,7 +250,6 @@ def ListInitialize(val, initializer, has_plus, blame_loc, arith_ev):
             raise AssertionError(val.tag())
 
 
-# XXX---Remove the cases for BashArray/BashAssoc on rhs.
 def PlusEquals(old_val, val):
     # type: (value_t, value_t) -> value_t
     """Implement s+=val, typeset s+=val, etc."""
@@ -269,58 +268,20 @@ def PlusEquals(old_val, val):
                 old_val = cast(value.Str, UP_old_val)
                 str_to_append = cast(value.Str, UP_val)
                 val = value.Str(old_val.s + str_to_append.s)
-
-            elif tag in (value_e.InternalStringArray, value_e.BashArray,
-                         value_e.BashAssoc):
-                e_die("Can't append array to string")
-
             else:
                 raise AssertionError()  # parsing should prevent this
 
         elif case(value_e.InternalStringArray, value_e.BashArray):
             if tag == value_e.Str:
                 e_die("Can't append string to array")
-            elif tag in (value_e.InternalStringArray, value_e.BashArray):
-                if tag == value_e.InternalStringArray:
-                    array_rhs = cast(value.InternalStringArray, UP_val)
-                    strs = bash_impl.InternalStringArray_GetValues(array_rhs)
-                else:
-                    sparse_rhs = cast(value.BashArray, UP_val)
-                    strs = bash_impl.BashArray_GetValues(sparse_rhs)
-
-                # We modify the original instance so that change is
-                # visible to other references (which may exist in YSH)
-                if old_val.tag() == value_e.InternalStringArray:
-                    array_lhs = cast(value.InternalStringArray, UP_old_val)
-                    bash_impl.InternalStringArray_AppendValues(array_lhs, strs)
-                    val = array_lhs
-                else:
-                    sparse_lhs = cast(value.BashArray, UP_old_val)
-                    bash_impl.BashArray_AppendValues(sparse_lhs, strs)
-                    val = sparse_lhs
-
-            elif tag == value_e.BashAssoc:
-                e_die("Can't append an associative array to an indexed array")
-
             else:
                 raise AssertionError()  # parsing should prevent this
 
         elif case(value_e.BashAssoc):
             if tag == value_e.Str:
                 e_die("Can't append string to associative arrays")
-
-            elif tag in (value_e.InternalStringArray, value_e.BashArray):
-                e_die("Can't append an assoxiative array to indexed arrays")
-
-            elif tag == value_e.BashAssoc:
-                assoc_lhs = cast(value.BashAssoc, UP_old_val)
-                assoc_rhs = cast(value.BashAssoc, UP_val)
-                d = bash_impl.BashAssoc_GetDict(assoc_rhs)
-                bash_impl.BashAssoc_AppendDict(assoc_lhs, d)
-                val = assoc_lhs
-
             else:
-                raise AssertionError()  # parsing should prevent this
+                raise AssertionError()  # parsing should prrevent this
 
         else:
             e_die("Can't append to value of type %s" % ui.ValType(old_val))

--- a/osh/cmd_parse_test.py
+++ b/osh/cmd_parse_test.py
@@ -399,13 +399,13 @@ class ArrayTest(unittest.TestCase):
         # Empty array
         node = assert_ParseCommandList(self, 'empty=()')
         self.assertEqual(['empty'], [p.lhs.name for p in node.pairs])
-        self.assertEqual([], node.pairs[0].rhs.parts[0].words)  # No words
+        self.assertEqual([], node.pairs[0].rhs.parts[0].pairs)  # No words
         self.assertEqual(command_e.ShAssignment, node.tag())
 
         # Array with 3 elements
         node = assert_ParseCommandList(self, 'array=(a b c)')
         self.assertEqual(['array'], [p.lhs.name for p in node.pairs])
-        self.assertEqual(3, len(node.pairs[0].rhs.parts[0].words))
+        self.assertEqual(3, len(node.pairs[0].rhs.parts[0].pairs))
         self.assertEqual(command_e.ShAssignment, node.tag())
 
         # Array literal can't come after word

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -393,7 +393,7 @@ def _ParseOshInteger(s, blame_loc):
         return (False, mops.BigInt(0))  # not an integer
 
 
-class ArithEvaluator(object):
+class ArithEvaluator(bash_impl.ArrayIndexEvaluator):
     """Shared between arith and bool evaluators.
 
     They both:
@@ -411,6 +411,7 @@ class ArithEvaluator(object):
             errfmt,  # type: ui.ErrorFormatter
     ):
         # type: (...) -> None
+        bash_impl.ArrayIndexEvaluator.__init__(self)
         self.word_ev = None  # type: word_eval.StringWordEvaluator
         self.mem = mem
         self.exec_opts = exec_opts
@@ -422,7 +423,7 @@ class ArithEvaluator(object):
         # type: () -> None
         assert self.word_ev is not None
 
-    def _StringToBigInt(self, s, blame_loc):
+    def StringToBigInt(self, s, blame_loc):
         # type: (str, loc_t) -> mops.BigInt
         """Use bash-like rules to coerce a string to an integer.
 
@@ -498,7 +499,7 @@ class ArithEvaluator(object):
                 elif case(value_e.Str):
                     val = cast(value.Str, UP_val)
                     # calls e_strict
-                    return self._StringToBigInt(val.s, loc.Arith(blame))
+                    return self.StringToBigInt(val.s, loc.Arith(blame))
 
         except error.Strict as e:
             if self.exec_opts.strict_arith():
@@ -1127,7 +1128,7 @@ class BoolEvaluator(ArithEvaluator):
         # Used by both [[ $x -gt 3 ]] and $(( x ))
         else:
             try:
-                i = self._StringToBigInt(s, blame_loc)
+                i = self.StringToBigInt(s, blame_loc)
             except error.Strict as e:
                 if self.bracket or self.exec_opts.strict_arith():
                     raise

--- a/osh/word_.py
+++ b/osh/word_.py
@@ -97,7 +97,7 @@ def _EvalWordPart(part):
 
             return True, ''.join(strs), True  # At least one part was quoted!
 
-        elif case(word_part_e.ShArrayLiteral, word_part_e.BashAssocLiteral,
+        elif case(word_part_e.ShArrayLiteral, word_part_e.InitializerLiteral,
                   word_part_e.ZshVarSub, word_part_e.CommandSub,
                   word_part_e.SimpleVarSub, word_part_e.BracedVarSub,
                   word_part_e.TildeSub, word_part_e.ArithSub,
@@ -398,8 +398,7 @@ def HasArrayPart(w):
     # type: (CompoundWord) -> bool
     """Used in cmd_parse."""
     for part in w.parts:
-        if part.tag() in (word_part_e.ShArrayLiteral,
-                          word_part_e.BashAssocLiteral):
+        if part.tag() == word_part_e.InitializerLiteral:
             return True
     return False
 
@@ -530,8 +529,10 @@ def DetectAssocPair(w):
             key = CompoundWord(parts[1:i])  # $x$y
             value = CompoundWord(parts[i + 1:])  # $a$b from
 
+            has_plus = lexer.IsPlusEquals(cast(Token, parts[i]))
+
             # Type-annotated intermediate value for mycpp translation
-            return AssocPair(key, value)
+            return AssocPair(key, value, has_plus)
 
     return None
 

--- a/osh/word_.py
+++ b/osh/word_.py
@@ -97,7 +97,7 @@ def _EvalWordPart(part):
 
             return True, ''.join(strs), True  # At least one part was quoted!
 
-        elif case(word_part_e.ShArrayLiteral, word_part_e.InitializerLiteral,
+        elif case(word_part_e.YshArrayLiteral, word_part_e.InitializerLiteral,
                   word_part_e.ZshVarSub, word_part_e.CommandSub,
                   word_part_e.SimpleVarSub, word_part_e.BracedVarSub,
                   word_part_e.TildeSub, word_part_e.ArithSub,

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -14,7 +14,7 @@ from _devbuild.gen.syntax_asdl import (
     bracket_op_e,
     suffix_op,
     suffix_op_e,
-    ShArrayLiteral,
+    YshArrayLiteral,
     SingleQuoted,
     DoubleQuoted,
     word_e,
@@ -1843,8 +1843,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
         UP_part = part
         with tagswitch(part) as case:
-            if case(word_part_e.ShArrayLiteral):
-                part = cast(ShArrayLiteral, UP_part)
+            if case(word_part_e.YshArrayLiteral):
+                part = cast(YshArrayLiteral, UP_part)
                 e_die("Unexpected array literal", loc.WordPart(part))
             elif case(word_part_e.InitializerLiteral):
                 part = cast(word_part.InitializerLiteral, UP_part)

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -1641,7 +1641,7 @@ class WordParser(WordEmitter):
             with tagswitch(w) as case:
                 if case(word_e.Operator):
                     tok = cast(Token, w)
-                    if tok.id == Id.Right_ShArrayLiteral:
+                    if tok.id == Id.Right_Initializer:
                         right_token = tok
                         done = True  # can't use break here
                     # Unlike command parsing, array parsing allows embedded \n.
@@ -1710,7 +1710,7 @@ class WordParser(WordEmitter):
             # _ReadWord.
             next_id = self.lexer.LookPastSpace(lex_mode)
             if next_id == Id.Op_LParen:
-                self.lexer.PushHint(Id.Op_RParen, Id.Right_ShArrayLiteral)
+                self.lexer.PushHint(Id.Op_RParen, Id.Right_Initializer)
                 part2 = self._ReadArrayLiteral()
                 parts.append(part2)
 
@@ -2006,8 +2006,7 @@ class WordParser(WordEmitter):
 
         elif self.token_kind == Kind.Right:
             if self.token_type not in (Id.Right_Subshell, Id.Right_ShFunction,
-                                       Id.Right_CasePat,
-                                       Id.Right_ShArrayLiteral):
+                                       Id.Right_CasePat, Id.Right_Initializer):
                 raise AssertionError(self.cur_token)
 
             self._SetNext(lex_mode)

--- a/spec/assign-extended.test.sh
+++ b/spec/assign-extended.test.sh
@@ -1,5 +1,4 @@
 ## compare_shells: bash-4.4 mksh
-## oils_failures_allowed: 1
 
 # Extended assignment language, e.g. typeset, declare, arrays, etc.
 # Things that dash doesn't support.

--- a/spec/assoc.test.sh
+++ b/spec/assoc.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash-4.4
-## oils_failures_allowed: 3
+## oils_failures_allowed: 2
 
 
 # NOTE:
@@ -617,8 +617,6 @@ argv.py "${A[@]}"
 declare -a arr=( [30]=a b [40]=x y)
 argv.py "${!arr[@]}"
 argv.py "${arr[@]}"
-
-# osh says "expected associative array pair"
 
 ## STDOUT:
 ['30', '31', '40', '41']

--- a/spec/assoc.test.sh
+++ b/spec/assoc.test.sh
@@ -68,20 +68,6 @@ status=2
 status=0
 ## END
 
-
-#### Initializing indexed array with assoc array
-declare -a a=([xx]=1 [yy]=2 [zz]=3)
-echo status=$?
-argv.py "${a[@]}"
-## STDOUT:
-status=2
-[]
-## END
-## BUG bash STDOUT:
-status=0
-['3']
-## END
-
 #### create empty assoc array, put, then get
 declare -A A  # still undefined
 argv.py "${A[@]}"
@@ -439,7 +425,8 @@ v
 -{a,b}-
 ## END
 
-#### bash mangles array #1
+#### bash mangles indexed array #1 (associative array is OK)
+declare -A a
 a=([k1]=v1 [k2]=v2)
 echo ${a["k1"]}
 echo ${a["k2"]}
@@ -447,19 +434,13 @@ echo ${a["k2"]}
 v1
 v2
 ## END
-## BUG bash STDOUT:
-v2
-v2
-## END
 
-#### bash mangles array and brace #2
+#### bash mangles indexed array #2 (associative array is OK)
+declare -A a
 a=([k2]=-{a,b}-)
 echo ${a["k2"]}
 ## STDOUT:
 -{a,b}-
-## END
-## BUG bash STDOUT:
-[k2]=-a-
 ## END
 
 #### declare -A A=() allowed

--- a/spec/ble-idioms.test.sh
+++ b/spec/ble-idioms.test.sh
@@ -313,3 +313,218 @@ echo "${a['hello']}"
 ## END
 
 ## N-I zsh/mksh/ash stdout-json: ""
+
+
+#### InitializerList (BashArray): index increments with
+case $SH in zsh|mksh|ash) exit 99;; esac
+a=([100]=1 2 3 4)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=([100]=1 2 3 4 [5]=a b c d)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['100', '101', '102', '103']
+vals: ['1', '2', '3', '4']
+keys: ['5', '6', '7', '8', '100', '101', '102', '103']
+vals: ['a', 'b', 'c', 'd', '1', '2', '3', '4']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+#### InitializerList (BashArray): [k]=$v and [k]="$@"
+case $SH in zsh|mksh|ash) exit 99;; esac
+i=5
+v='1 2 3'
+a=($v [i]=$v)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+
+x=(3 5 7)
+a=($v [i]="${x[*]}")
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=($v [i]="${x[@]}")
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=($v [i]=${x[*]})
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=($v [i]=${x[@]})
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['0', '1', '2', '5']
+vals: ['1', '2', '3', '1 2 3']
+keys: ['0', '1', '2', '5']
+vals: ['1', '2', '3', '3 5 7']
+keys: ['0', '1', '2', '5']
+vals: ['1', '2', '3', '3 5 7']
+keys: ['0', '1', '2', '5']
+vals: ['1', '2', '3', '3 5 7']
+keys: ['0', '1', '2', '5']
+vals: ['1', '2', '3', '3 5 7']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+
+#### InitializerList (BashAssoc): [k]=$v and [k]="$@"
+case $SH in zsh|mksh|ash) exit 99;; esac
+i=5
+v='1 2 3'
+declare -A a
+a=([i]=$v)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+
+x=(3 5 7)
+a=([i]="${x[*]}")
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=([i]="${x[@]}")
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=([i]=${x[*]})
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=([i]=${x[@]})
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['i']
+vals: ['1 2 3']
+keys: ['i']
+vals: ['3 5 7']
+keys: ['i']
+vals: ['3 5 7']
+keys: ['i']
+vals: ['3 5 7']
+keys: ['i']
+vals: ['3 5 7']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+#### InitializerList (BashArray): append to element
+case $SH in zsh|mksh|ash) exit 99;; esac
+hello=100
+a=([hello]=1 [hello]+=2)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a+=([hello]+=:34 [hello]+=:56)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['100']
+vals: ['12']
+keys: ['100']
+vals: ['12:34:56']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+#### InitializerList (BashAssoc): append to element
+case $SH in zsh|mksh|ash) exit 99;; esac
+declare -A a
+hello=100
+a=([hello]=1 [hello]+=2)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a+=([hello]+=:34 [hello]+=:56)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['hello']
+vals: ['12']
+keys: ['hello']
+vals: ['12:34:56']
+## END
+# Bash >= 5.1 has a bug. Bash <= 5.0 is OK.
+## BUG bash STDOUT:
+keys: ['hello']
+vals: ['2']
+keys: ['hello']
+vals: ['2:34:56']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+#### InitializerList (BashAssoc): non-index forms of element
+case $SH in zsh|mksh|ash) exit 99;; esac
+declare -A a
+a=([j]=1 2 3 4)
+echo "status=$?"
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## status: 1
+## STDOUT:
+## END
+# Bash outputs warning messages and succeeds (exit status 0)
+## BUG bash status: 0
+## BUG bash STDOUT:
+status=0
+keys: ['j']
+vals: ['1']
+## END
+## BUG bash STDERR:
+bash: line 3: a: 2: must use subscript when assigning associative array
+bash: line 3: a: 3: must use subscript when assigning associative array
+bash: line 3: a: 4: must use subscript when assigning associative array
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+
+#### InitializerList (BashArray): evaluation order (1)
+# RHS of [k]=v are expanded when the initializer list is instanciated.  For the
+# indexed array, the array indices are evaluated when the array is modified.
+case $SH in zsh|mksh|ash) exit 99;; esac
+i=1
+a=([100+i++]=$((i++)) [200+i++]=$((i++)) [300+i++]=$((i++)))
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['104', '205', '306']
+vals: ['1', '2', '3']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+
+#### InitializerList (BashArray): evaluation order (2)
+# When evaluating the index, the modification to the array by the previous item
+# of the initializer list is visible to the current item.
+case $SH in zsh|mksh|ash) exit 99;; esac
+a=([0]=1+2+3 [a[0]]=10 [a[6]]=hello)
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['0', '6', '10']
+vals: ['1+2+3', '10', 'hello']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""
+
+
+#### InitializerList (BashArray): evaluation order (3)
+# RHS should be expanded before any modification to the array.
+case $SH in zsh|mksh|ash) exit 99;; esac
+a=(old1 old2 old3)
+a=("${a[2]}" "${a[0]}" "${a[1]}" "${a[2]}" "${a[0]}")
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+a=(old1 old2 old3)
+old1=101 old2=102 old3=103
+new1=201 new2=202 new3=203
+a+=([0]=new1 [1]=new2 [2]=new3 [5]="${a[2]}" [a[0]]="${a[0]}" [a[1]]="${a[1]}")
+printf 'keys: '; argv.py "${!a[@]}"
+printf 'vals: '; argv.py "${a[@]}"
+## STDOUT:
+keys: ['0', '1', '2', '3', '4']
+vals: ['old3', 'old1', 'old2', 'old3', 'old1']
+keys: ['0', '1', '2', '5', '201', '202']
+vals: ['new1', 'new2', 'new3', 'old3', 'old1', 'old2']
+## END
+## N-I zsh/mksh/ash status: 99
+## N-I zsh/mksh/ash stdout-json: ""

--- a/spec/ble-sparse.test.sh
+++ b/spec/ble-sparse.test.sh
@@ -1185,7 +1185,7 @@ json write (crash_dump.var_stack[0].a)
 
 
 #### Regression: a[-1]=1
-case $SH in mksh) exit ;; esac
+case $SH in mksh) exit 99;; esac
 
 a[-1]=1
 
@@ -1200,5 +1200,49 @@ a[-1]=1
 ## OK bash STDERR:
 bash: line 3: a[-1]: bad array subscript
 ## END
-## N-I mksh status: 0
+## N-I mksh status: 99
 ## N-I mksh stderr-json: ""
+
+
+#### Initializing indexed array with ([index]=value)
+case $SH in mksh) exit 99;; esac
+declare -a a=([xx]=1 [yy]=2 [zz]=3)
+echo status=$?
+argv.py "${a[@]}"
+## STDOUT:
+status=0
+['3']
+## END
+## N-I mksh status: 99
+## N-I mksh stdout-json: ""
+
+
+#### bash mangles indexed array #1 (keys undergoes arithmetic evaluation)
+case $SH in mksh) exit 99;; esac
+# Note: This and next tests have originally been in "spec/assign.test.sh" and
+# compared the behavior of OSH's BashAssoc and Bash's indexed array.  After
+# supporting "arr=([index]=value)" for indexed arrays, the test was adjusted
+# and copied here. See also the corresponding tests in "spec/assign.test.sh"
+a=([k1]=v1 [k2]=v2)
+echo ${a["k1"]}
+echo ${a["k2"]}
+## STDOUT:
+v2
+v2
+## END
+## N-I mksh status: 99
+## N-I mksh stdout-json: ""
+
+
+#### bash mangles indexed array #2 (Bash does not recognize [index]=brace-expansion)
+case $SH in mksh) exit 99;; esac
+a=([k2]=-{a,b}-)
+echo ${a["k2"]}
+## STDOUT:
+-{a,b}-
+## END
+## BUG bash STDOUT:
+[k2]=-a-
+## END
+## N-I mksh status: 99
+## N-I mksh stdout-json: ""

--- a/spec/ysh-printing.test.sh
+++ b/spec/ysh-printing.test.sh
@@ -212,8 +212,8 @@ pp test_ ({k:assoc})
 #### BashAssoc, long
 declare -A assoc_0=()
 declare -A assoc_1=([1]=one)
-declare assoc_3=([1]=one [two]=2 [3]=three)
-declare assoc_long=([Lorem]=ipsum [dolor]="sit amet," ['consectetur adipiscing']="elit, sed" [do]="eiusmod.")
+declare -A assoc_3=([1]=one [two]=2 [3]=three)
+declare -A assoc_long=([Lorem]=ipsum [dolor]="sit amet," ['consectetur adipiscing']="elit, sed" [do]="eiusmod.")
 = assoc_0
 = assoc_1
 = assoc_3

--- a/tools/ysh_ify.py
+++ b/tools/ysh_ify.py
@@ -1019,8 +1019,9 @@ class YshPrinter(object):
         UP_node = node
 
         with tagswitch(node) as case:
-            if case(word_part_e.ShArrayLiteral, word_part_e.InitializerLiteral,
-                    word_part_e.TildeSub, word_part_e.ExtGlob):
+            if case(word_part_e.YshArrayLiteral,
+                    word_part_e.InitializerLiteral, word_part_e.TildeSub,
+                    word_part_e.ExtGlob):
                 pass
 
             elif case(word_part_e.EscapedLiteral):

--- a/tools/ysh_ify.py
+++ b/tools/ysh_ify.py
@@ -1019,7 +1019,7 @@ class YshPrinter(object):
         UP_node = node
 
         with tagswitch(node) as case:
-            if case(word_part_e.ShArrayLiteral, word_part_e.BashAssocLiteral,
+            if case(word_part_e.ShArrayLiteral, word_part_e.InitializerLiteral,
                     word_part_e.TildeSub, word_part_e.ExtGlob):
                 pass
 

--- a/tools/ysh_ify.py
+++ b/tools/ysh_ify.py
@@ -201,7 +201,7 @@ def PrintTokens(arena):
         print('%s' % arena.tokens[0])
         return
 
-    # TODO: 
+    # TODO:
     # - TSV8: end position, token type
     #   - then an option to print token text, as a J8 string
     # - and then there can be a separate tool to number the columns

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -15,7 +15,7 @@ from _devbuild.gen.syntax_asdl import (
     SingleQuoted,
     DoubleQuoted,
     BracedVarSub,
-    ShArrayLiteral,
+    YshArrayLiteral,
     CommandSub,
     expr,
     expr_e,
@@ -1216,8 +1216,8 @@ class ExprEvaluator(object):
                     else:
                         return value.Str(stdout_str)
 
-            elif case(expr_e.ShArrayLiteral):  # var x = :| foo *.py |
-                node = cast(ShArrayLiteral, UP_node)
+            elif case(expr_e.YshArrayLiteral):  # var x = :| foo *.py |
+                node = cast(YshArrayLiteral, UP_node)
                 words = braces.BraceExpandWords(node.words)
                 strs = self.word_ev.EvalWordSequence(words)
                 #log('ARRAY LITERAL EVALUATED TO -> %s', strs)

--- a/ysh/expr_parse.py
+++ b/ysh/expr_parse.py
@@ -180,7 +180,7 @@ def _PushYshTokens(parse_ctx, gr, p, lex):
                       Id.Left_PercentParen):  # :|  %(  LEGACY!
             left_tok = tok
             if tok.id == Id.Left_PercentParen:
-                lex.PushHint(Id.Op_RParen, Id.Right_ShArrayLiteral)
+                lex.PushHint(Id.Op_RParen, Id.Right_Initializer)
 
             # Blame the opening token
             line_reader = reader.DisallowedLineReader(parse_ctx.arena, tok)
@@ -193,7 +193,7 @@ def _PushYshTokens(parse_ctx, gr, p, lex):
                 with tagswitch(w) as case:
                     if case(word_e.Operator):
                         tok = cast(Token, w)
-                        if tok.id == Id.Right_ShArrayLiteral:
+                        if tok.id == Id.Right_Initializer:
                             if left_tok.id != Id.Left_PercentParen:
                                 p_die('Expected ) to close', left_tok)
                             close_tok = tok

--- a/ysh/expr_parse.py
+++ b/ysh/expr_parse.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 from _devbuild.gen.syntax_asdl import (loc, Token, DoubleQuoted, SingleQuoted,
-                                       CommandSub, ShArrayLiteral,
+                                       CommandSub, YshArrayLiteral,
                                        CompoundWord, word_part_t, word_e)
 from _devbuild.gen.id_kind_asdl import Id, Kind, Id_str
 from _devbuild.gen.types_asdl import lex_mode_e
@@ -220,7 +220,7 @@ def _PushYshTokens(parse_ctx, gr, p, lex):
 
             typ = Id.Expr_CastedDummy
 
-            lit_part = ShArrayLiteral(left_tok, words3, close_tok)
+            lit_part = YshArrayLiteral(left_tok, words3, close_tok)
             opaque = cast(Token, lit_part)  # HACK for expr_to_ast
             done = p.addtoken(typ, opaque, gr.tokens[typ])
             assert not done  # can't end the expression

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -11,7 +11,7 @@ from _devbuild.gen.syntax_asdl import (
     SingleQuoted,
     BracedVarSub,
     CommandSub,
-    ShArrayLiteral,
+    YshArrayLiteral,
     command,
     expr,
     expr_e,
@@ -689,10 +689,10 @@ class Transformer(object):
         #
 
         elif typ == grammar_nt.sh_array_literal:
-            return cast(ShArrayLiteral, pnode.GetChild(1).tok)
+            return cast(YshArrayLiteral, pnode.GetChild(1).tok)
 
         elif typ == grammar_nt.old_sh_array_literal:
-            return cast(ShArrayLiteral, pnode.GetChild(1).tok)
+            return cast(YshArrayLiteral, pnode.GetChild(1).tok)
 
         elif typ == grammar_nt.sh_command_sub:
             return cast(CommandSub, pnode.GetChild(1).tok)

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -252,7 +252,7 @@ array_item: (
 sh_array_literal: ':|' Expr_CastedDummy Op_Pipe
 
 # TODO: remove old array
-old_sh_array_literal: '%(' Expr_CastedDummy Right_ShArrayLiteral
+old_sh_array_literal: '%(' Expr_CastedDummy Right_Initializer
 sh_command_sub: ( '$(' | '@(' | '^(' ) Expr_CastedDummy Eof_RParen
 
 # "   $"   """   $"""   ^" 


### PR DESCRIPTION
See commit messages.

### Note: Now `([k1]=v1 [k2]=v2)` is not a literal for BashAssoc

The construct `(...)` in `a=(...)` and `a+=(...)` always produces the new type InitializerList regardless of the forms of its items. The LHS object receives the initializer list and reads items one by one to modify its content. When the variable `a` is Undef, `a` is initialized to be an indexed array and processes the initializer list, so `a=([k1]=v1 [k2]=v2)` produces a sparse array (but not an associative array).