### PR TITLE
[osh] Promote a string to an array with `str+=(...)`

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -261,7 +261,7 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags, arith_ev,
                     ui.ValType(old_val), pair.blame_word)
 
         val = cmd_eval.ListInitializeTarget(val, initializer, pair.plus_eq,
-                                            pair.blame_word)
+                                            mem.exec_opts, pair.blame_word)
     elif pair.plus_eq:
         old_val = sh_expr_eval.OldValue(
             lval,

--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -242,12 +242,18 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags, arith_ev,
                     "Can't convert type %s into BashArray" %
                     ui.ValType(old_val), pair.blame_word)
         elif flag_A:
-            if old_val.tag() in (value_e.Undef, value_e.Str):
-                # Note: We explicitly initialize BashAssoc for Undef and Str.
-                #   When applying +=() to Str, we associate an old value to the
-                #   key '0'.
+            if old_val.tag() == value_e.Undef:
+                # Note: We explicitly initialize BashAssoc for Undef.
+                val = bash_impl.BashAssoc_New()
+            elif old_val.tag() == value_e.Str:
+                # Note: We explicitly initialize BashAssoc for Str.  When
+                #   applying +=() to Str, we associate an old value to the key
+                #   '0'.  OSH disables this when strict_array is turned on.
                 assoc_val = bash_impl.BashAssoc_New()
-                if pair.plus_eq and old_val.tag() == value_e.Str:
+                if pair.plus_eq:
+                    if mem.exec_opts.strict_array():
+                        e_die("Can't convert Str to BashAssoc (strict_array)",
+                              pair.blame_word)
                     bash_impl.BashAssoc_SetElement(assoc_val, '0',
                                                    cast(value.Str, old_val).s)
                 val = assoc_val

--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -243,8 +243,14 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags, arith_ev,
                     ui.ValType(old_val), pair.blame_word)
         elif flag_A:
             if old_val.tag() in (value_e.Undef, value_e.Str):
-                # Note: We explicitly initialize BashAssoc for Undef.
-                val = bash_impl.BashAssoc_New()
+                # Note: We explicitly initialize BashAssoc for Undef and Str.
+                #   When applying +=() to Str, we associate an old value to the
+                #   key '0'.
+                assoc_val = bash_impl.BashAssoc_New()
+                if pair.plus_eq and old_val.tag() == value_e.Str:
+                    bash_impl.BashAssoc_SetElement(assoc_val, '0',
+                                                   cast(value.Str, old_val).s)
+                val = assoc_val
             elif old_val.tag() == value_e.BashAssoc:
                 # We do not need adjustments for -A.
                 pass

--- a/doc/ref/chap-osh-assign.md
+++ b/doc/ref/chap-osh-assign.md
@@ -81,9 +81,7 @@ In the first phase, the type adjustment is performed in the following way:
   element, where the original value is stored at index `0`.  If the assignment
   is performed through an assignment builtin and flag `-A` is supplied to the
   builtin, the assignment creates a BashAssoc with one element, where the
-  original value is stored at key `"0"`, instead of a BashArray.  If the
-  assignment operator is `+=`, OSH issues an error "Can't append an array to
-  string", while Bash is permissive.
+  original value is stored at key `"0"`, instead of a BashArray.
 - When the LHS is an indexed or associative arrays, the original array is
   directly used for the modification target.  If the
   assignment is performed through an assignment builtin and mismatching flag
@@ -121,17 +119,17 @@ These rules are summarized in the following table.
   - Str
   - (none)
   - BashArray with one element, with the original string at index 0
-  - OSH does not accept `+=`, so the element is never used
+  - <!-- empty -->
 - tr
   - <!-- empty -->
   - `-a`
   - BashArray with one element, with the original string at index 0
-  - OSH does not accept `+=`, so the element is never used
+  - <!-- empty -->
 - tr
   - <!-- empty -->
   - `-A`
   - BashAssoc with one element, with the original string at key `"0"`
-  - OSH does not accept `+=`, so the element is never used
+  - <!-- empty -->
 - tr
   - BashArray
   - (none)

--- a/doc/ref/chap-osh-assign.md
+++ b/doc/ref/chap-osh-assign.md
@@ -119,17 +119,17 @@ These rules are summarized in the following table.
   - Str
   - (none)
   - BashArray with one element, with the original string at index 0
-  - <!-- empty -->
+  - Error with `strict_array`
 - tr
   - <!-- empty -->
   - `-a`
   - BashArray with one element, with the original string at index 0
-  - <!-- empty -->
+  - Error with `strict_array`
 - tr
   - <!-- empty -->
   - `-A`
   - BashAssoc with one element, with the original string at key `"0"`
-  - <!-- empty -->
+  - Error with `strict_array`
 - tr
   - BashArray
   - (none)

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -193,9 +193,10 @@ def _HasManyStatuses(node):
 def ListInitializeTarget(old_val,
                          initializer,
                          has_plus,
+                         exec_opts,
                          blame_loc,
                          destructive=True):
-    # type: (value_t, value.InitializerList, bool, loc_t, bool) -> value_t
+    # type: (value_t, value.InitializerList, bool, optview.Exec, loc_t, bool) -> value_t
     UP_old_val = old_val
     with tagswitch(old_val) as case:
         if case(value_e.Undef):
@@ -625,6 +626,7 @@ class CommandEvaluator(object):
                 val = ListInitializeTarget(old_val,
                                            initializer,
                                            has_plus,
+                                           self.exec_opts,
                                            e_pair.left,
                                            destructive=False)
 
@@ -1041,7 +1043,7 @@ class CommandEvaluator(object):
                                                 node.left)
 
                 val = ListInitializeTarget(old_val, initializer, has_plus,
-                                           pair.left)
+                                           self.exec_opts, pair.left)
 
             elif has_plus:
                 # do not respect set -u

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -202,9 +202,10 @@ def ListInitializeTarget(old_val,
             return bash_impl.BashArray_New()
         elif case(value_e.Str):
             if has_plus:
-                e_die("Can't append array to string")
-
-            return bash_impl.BashArray_New()
+                old_val = cast(value.Str, UP_old_val)
+                return bash_impl.BashArray_FromList([old_val.s])
+            else:
+                return bash_impl.BashArray_New()
         elif case(value_e.BashArray):
             old_val = cast(value.BashArray, UP_old_val)
             if not destructive:

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -203,6 +203,9 @@ def ListInitializeTarget(old_val,
             return bash_impl.BashArray_New()
         elif case(value_e.Str):
             if has_plus:
+                if exec_opts.strict_array():
+                    e_die("Can't convert Str to BashArray (strict_array)",
+                          blame_loc)
                 old_val = cast(value.Str, UP_old_val)
                 return bash_impl.BashArray_FromList([old_val.s])
             else:

--- a/spec/append.test.sh
+++ b/spec/append.test.sh
@@ -48,13 +48,11 @@ argv.py "${y[@]}"
 #### error: s+=(my array)
 s='abc'
 s+=(d e f)
-echo $s
-## status: 1
-## stdout-json: ""
-## BUG bash/mksh status: 0
-## BUG bash/mksh stdout: abc
-## OK zsh status: 0
-## OK zsh stdout: abc d e f
+argv.py "${s[@]}"
+## status: 0
+## STDOUT:
+['abc', 'd', 'e', 'f']
+## END
 
 #### error: myarray+=s
 
@@ -78,16 +76,16 @@ typeset s+=(d e f)
 echo status=$?
 argv.py "${s[@]}"
 
-## status: 1
+## status: 0
 ## STDOUT:
-abc
-## END
-## OK bash status: 0
-## OK bash STDOUT:
 abc
 status=0
 ['abc', 'd', 'e', 'f']
 ## END
+## N-I mksh/zsh status: 1
+## N-I mksh/zsh stdout: abc
+## N-I mksh stderr: mksh: <stdin>[4]: syntax error: '(' unexpected
+## N-I zsh stderr: typeset: not valid in this context: s+
 
 #### error: typeset myarray+=s
 typeset a=(x y)

--- a/spec/array-literal.test.sh
+++ b/spec/array-literal.test.sh
@@ -57,3 +57,57 @@ status=1
 status=1
 ['x', 'y', 'z']
 ## END
+
+#### s+=() with strict_array
+case $SH in bash) ;; *) shopt --set strict_array;; esac
+
+s1=hello
+s2=world
+
+# Overwriting Str with a new BashArray is allowed
+eval 's1=(1 2 3 4)'
+echo status=$?
+declare -p s1
+# Promoting Str to a BashArray is disallowed
+eval 's2+=(1 2 3 4)'
+echo status=$?
+declare -p s2
+## STDOUT:
+status=0
+declare -a s1=(1 2 3 4)
+status=1
+declare -- s2=world
+## END
+## N-I bash STDOUT:
+status=0
+declare -a s1=([0]="1" [1]="2" [2]="3" [3]="4")
+status=0
+declare -a s2=([0]="world" [1]="1" [2]="2" [3]="3" [4]="4")
+## END
+
+#### declare -A s+=() with strict_array
+case $SH in bash) ;; *) shopt --set strict_array;; esac
+
+s1=hello
+s2=world
+
+# Overwriting Str with a new BashAssoc is allowed
+eval 'declare -A s1=([a]=x [b]=y)'
+echo status=$?
+declare -p s1
+# Promoting Str to a BashAssoc is disallowed
+eval 'declare -A s2+=([a]=x [b]=y)'
+echo status=$?
+declare -p s2
+## STDOUT:
+status=0
+declare -A s1=(['a']=x ['b']=y)
+status=1
+declare -- s2=world
+## END
+## N-I bash STDOUT:
+status=0
+declare -A s1=([b]="y" [a]="x" )
+status=0
+declare -A s2=([0]="world" [b]="y" [a]="x" )
+## END


### PR DESCRIPTION
In Bash, string variables can always be used as if it is an array. This is also the case with `str+=(1 2 3)`, which converts the string variable to an array and modifies the content.