### PR TITLE
[builtin/assign_osh] Disallow overwriting existing BashArray/BashAssoc

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -231,30 +231,25 @@ def _AssignVarForBuiltin(mem, rval, pair, which_scopes, flags, arith_ev,
 
         val = old_val
         if flag_a:
-            if old_val.tag() == value_e.BashAssoc:
-                # Note: OSH allows overwriting an existing BashArray with an
-                #   empty BashArray.  Bash does not allow this.
-                val = bash_impl.BashArray_New()
-            elif old_val.tag() in (value_e.Undef, value_e.Str,
-                                   value_e.BashArray):
+            if old_val.tag() in (value_e.Undef, value_e.Str,
+                                 value_e.BashArray):
                 # We do not need adjustemnts for -a.  These types are
                 # consistently handled within ListInitialize
                 pass
             else:
+                # Note: BashAssoc cannot be converted to a BashArray
                 e_die(
                     "Can't convert type %s into BashArray" %
                     ui.ValType(old_val), pair.blame_word)
         elif flag_A:
-            if old_val.tag() in (value_e.Undef, value_e.Str,
-                                 value_e.BashArray):
+            if old_val.tag() in (value_e.Undef, value_e.Str):
                 # Note: We explicitly initialize BashAssoc for Undef.
-                # Note: OSH allows overwriting an existing BashArray with an
-                #   empty BashAssoc.  Bash does not allow this.
                 val = bash_impl.BashAssoc_New()
             elif old_val.tag() == value_e.BashAssoc:
                 # We do not need adjustments for -A.
                 pass
             else:
+                # Note: BashArray cannot be converted to a BashAssoc
                 e_die(
                     "Can't convert type %s into BashAssoc" %
                     ui.ValType(old_val), pair.blame_word)

--- a/doc/ref/chap-osh-assign.md
+++ b/doc/ref/chap-osh-assign.md
@@ -151,8 +151,8 @@ These rules are summarized in the following table.
 - tr
   - <!-- empty -->
   - `-A`
-  - an empty BashAssoc
-  - Error in Bash
+  - N/A
+  - Error
 - tr
   - BashAssoc
   - (none)
@@ -161,8 +161,8 @@ These rules are summarized in the following table.
 - tr
   - <!-- empty -->
   - `-a`
-  - an empty BashArray
-  - Error in Bash
+  - N/A
+  - Error
 - tr
   - <!-- empty -->
   - `-A`

--- a/spec/array-literal.test.sh
+++ b/spec/array-literal.test.sh
@@ -40,3 +40,20 @@ echo ${a["k2"]}
 ## BUG bash STDOUT:
 [k2]=-a-
 ## END
+
+#### BashArray cannot be changed to BashAssoc and vice versa
+declare -a a=(1 2 3 4)
+eval 'declare -A a=([a]=x [b]=y [c]=z)'
+echo status=$?
+argv.py "${a[@]}"
+
+declare -A A=([a]=x [b]=y [c]=z)
+eval 'declare -a A=(1 2 3 4)'
+echo status=$?
+argv.py $(printf '%s\n' "${A[@]}" | sort)
+## STDOUT:
+status=1
+['1', '2', '3', '4']
+status=1
+['x', 'y', 'z']
+## END


### PR DESCRIPTION
https://github.com/oils-for-unix/oils/pull/2279#discussion_r1976468318

This makes the behavior consistent with Bash.