### PR TITLE
Add two failing tests for kill builtin

### DIFF
--- a/spec/builtin-kill.test.sh
+++ b/spec/builtin-kill.test.sh
@@ -1,0 +1,28 @@
+## oils_failures_allowed: 2
+## compare_shells: dash bash-4.4 mksh zsh
+
+# Tests for builtins having to do with killing a process
+
+#### Kills the process with SIGTERM
+# Test 1: Basic SIGTERM
+sleep 0.1 &
+pid=$!
+kill -15 $pid
+wait $pid
+echo $?  # Should be 143 (128 + SIGTERM)
+## STDOUT:
+143
+## END
+# For some reason mksh doesn't return the same as the others.
+## OK mksh stdout: 0
+
+#### Kills the process with SIGKILL
+# Test 2: Basic SIGKILL
+sleep 0.1 & 
+pid=$!
+kill -9 $pid 
+wait $pid
+echo $?  # Must be 137 (128 + SIGKILL) 
+## STDOUT:
+137
+## END

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -174,6 +174,10 @@ builtin-process() {
   test/spec-py.sh run-file builtin-process "$@"
 }
 
+builtin-kill() {
+  test/spec-py.sh run-file builtin-kill "$@"
+}
+
 builtin-read() {
   test/spec-py.sh run-file builtin-read "$@"
 }


### PR DESCRIPTION
Adds two failing tests for #834. mksh is the only one with slightly unusual behavior in that it returns a different code. 