### PR TITLE
Add and expand bind -x `READLINE_*` env var tests

### DIFF
--- a/spec/stateful/bind.py
+++ b/spec/stateful/bind.py
@@ -41,7 +41,7 @@ def bind_plain(sh):
 
     # There aren't many readline fns that will work nicely with pexpect (e.g., cursor-based fns)
     # Editing input seems like a reasonable choice
-    send_bind(sh, ''' '"\C-x\C-h": backward-delete-char' ''')
+    send_bind(sh, r''' '"\C-x\C-h": backward-delete-char' ''')
     expect_prompt(sh)
 
     sh.send("echo FOOM")
@@ -64,14 +64,14 @@ def bind_r_for_bind_x_osh_fn(sh):
     add_foo_fn(sh)
     expect_prompt(sh)
 
-    send_bind(sh, """-x '"\C-o": foo' """)
+    send_bind(sh, r"""-x '"\C-o": foo' """)
     expect_prompt(sh)
 
     sh.sendcontrol('o')
     time.sleep(0.1)
     sh.expect("FOO")
 
-    send_bind(sh, '-r "\C-o" ')
+    send_bind(sh, r'-r "\C-o" ')
 
     sh.sendcontrol('o')
     time.sleep(0.1)
@@ -87,7 +87,7 @@ def bind_x(sh):
     add_foo_fn(sh)
     expect_prompt(sh)
 
-    send_bind(sh, """-x '"\C-o": foo' """)
+    send_bind(sh, r"""-x '"\C-o": foo' """)
     expect_prompt(sh)
 
     sh.sendcontrol('o')
@@ -103,7 +103,7 @@ def bind_x_runtime_envvar_vals(sh):
 
     sh.sendline("export BIND_X_VAR=foo")
 
-    send_bind(sh, """-x '"\C-o": echo $BIND_X_VAR' """)
+    send_bind(sh, r"""-x '"\C-o": echo $BIND_X_VAR' """)
     expect_prompt(sh)
 
     sh.sendline("export BIND_X_VAR=bar")
@@ -120,7 +120,7 @@ def bind_x_readline_line(sh):
     "test bind -x for correctly setting $READLINE_LINE for the cmd"
     expect_prompt(sh)
 
-    send_bind(sh, """-x '"\C-o": echo Current line is: $READLINE_LINE' """)
+    send_bind(sh, r"""-x '"\C-o": echo Current line is: $READLINE_LINE' """)
     expect_prompt(sh)
 
     sh.send('abcdefghijklmnopqrstuvwxyz')
@@ -142,7 +142,7 @@ def bind_x_set_readline_line_to_uppercase(sh):
     """test bind -x for correctly using $READLINE_LINE changes"""
     expect_prompt(sh)
 
-    send_bind(sh, """-x '"\C-o": READLINE_LINE=${READLINE_LINE^^}' """)
+    send_bind(sh, r"""-x '"\C-o": READLINE_LINE=${READLINE_LINE^^}' """)
     expect_prompt(sh)
 
     sh.send('abcdefghijklmnopqrstuvwxyz')
@@ -164,7 +164,7 @@ def bind_x_readline_point(sh):
 
     expect_prompt(sh)
 
-    send_bind(sh, """-x '"\C-o": echo Cursor point at: $READLINE_POINT' """)
+    send_bind(sh, r"""-x '"\C-o": echo Cursor point at: $READLINE_POINT' """)
     expect_prompt(sh)
 
     sh.send(cmd_str)
@@ -247,7 +247,7 @@ def bind_u(sh):
     "test bind -u for unsetting all bindings to a fn"
     expect_prompt(sh)
 
-    send_bind(sh, "'\C-p: yank'")
+    send_bind(sh, r"'\C-p: yank'")
     expect_prompt(sh)
 
     send_bind(sh, "-u yank")
@@ -284,7 +284,7 @@ def bind_m(sh):
     send_bind(sh, "-u yank", "vi")
     expect_prompt(sh)
 
-    send_bind(sh, "'\C-p: yank'", "emacs")
+    send_bind(sh, r"'\C-p: yank'", "emacs")
     expect_prompt(sh)
 
     send_bind(sh, "-q yank", "vi")
@@ -304,7 +304,7 @@ def bind_f(sh):
     expect_prompt(sh)
 
     send_bind(sh, "-q downcase-word")
-    sh.expect('downcase-word can be invoked via.*"\\\C-o\\\C-s\\\C-h"')
+    sh.expect(r'downcase-word can be invoked via.*"\\C-o\\C-s\\C-h"')
 
 
 if __name__ == '__main__':

--- a/spec/stateful/harness.py
+++ b/spec/stateful/harness.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 import optparse
 import os
 import pexpect
+import re
 import signal
 import sys
 
@@ -49,12 +50,13 @@ def stop_process__hack(name, sig_num=signal.SIGSTOP):
 CASES = []
 
 
-def register(skip_shells=None, not_impl_shells=None):
+def register(skip_shells=None, not_impl_shells=None, needs_dimensions=False):
     skip_shells = skip_shells or []
     not_impl_shells = not_impl_shells or []
 
     def decorator(func):
-        CASES.append((func.__doc__, func, skip_shells, not_impl_shells))
+        CASES.append((func.__doc__, func, skip_shells, not_impl_shells,
+                      needs_dimensions))
         return func
 
     return decorator
@@ -67,6 +69,40 @@ class Result(object):
     FAIL = 4
 
 
+class TerminalDimensionEnvVars:
+    """
+    Context manager for setting and unsetting LINES and COLUMNS environment variables.
+    """
+
+    def __init__(self, lines: int, columns: int):
+        self.lines = lines
+        self.columns = columns
+        self.original_lines = None
+        self.original_columns = None
+
+    def __enter__(self):
+        # Save original values
+        self.original_lines = os.environ.get('LINES')
+        self.original_columns = os.environ.get('COLUMNS')
+
+        # Set new values
+        os.environ['LINES'] = str(self.lines)
+        os.environ['COLUMNS'] = str(self.columns)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Restore original values
+        if self.original_lines is None:
+            del os.environ['LINES']
+        else:
+            os.environ['LINES'] = self.original_lines
+
+        if self.original_columns is None:
+            del os.environ['COLUMNS']
+        else:
+            os.environ['COLUMNS'] = self.original_columns
+
+
 class TestRunner(object):
 
     def __init__(self, num_retries, pexpect_timeout, verbose, num_lines,
@@ -77,7 +113,7 @@ class TestRunner(object):
         self.num_lines = num_lines
         self.num_columns = num_columns
 
-    def RunOnce(self, shell_path, shell_label, func):
+    def RunOnce(self, shell_path, shell_label, func, test_params={}):
         sh_argv = []
         if shell_label in ('bash', 'osh'):
             sh_argv.extend(['--rcfile', '/dev/null'])
@@ -87,57 +123,44 @@ class TestRunner(object):
             sh_argv.append('--norc')
         #print(sh_argv)
 
-        # Set LINES and COLUMNS in case a program needs them (like pyte tests)
-        # Setting the dimensions kw param to spawn() is not sufficient
-        original_lines = os.environ.get('LINES')
-        original_columns = os.environ.get('COLUMNS')
-        os.environ['LINES'] = str(self.num_lines)
-        os.environ['COLUMNS'] = str(self.num_columns)
+        # Python 3: encoding required
+        sh = pexpect.spawn(
+            shell_path,
+            sh_argv,
+            encoding="utf-8",
+            dimensions=(self.num_lines, self.num_columns),
+            # Generally don't want local echo of input, it gets confusing fast.
+            echo=False,
+            timeout=self.pexpect_timeout,
+        )
 
+        sh.shell_label = shell_label  # for tests to use
+
+        if self.verbose:
+            sh.logfile = sys.stdout
+
+        ok = True
         try:
-            # Python 3: encoding required
-            sh = pexpect.spawn(
-                shell_path,
-                sh_argv,
-                encoding="utf-8",
-                dimensions=(self.num_lines, self.num_columns),
-                # Generally don't want local echo of input, it gets confusing fast.
-                echo=False,
-                timeout=self.pexpect_timeout,
-            )
-
-            sh.shell_label = shell_label  # for tests to use
-
-            if self.verbose:
-                sh.logfile = sys.stdout
-
-            ok = True
-            try:
+            # Support tests that need extra params (like dimensions), without
+            # impacting existing tests
+            if len(test_params) > 0:
+                func(sh, test_params)
+            else:
                 func(sh)
-            except Exception as e:
-                import traceback
-                traceback.print_exc(file=sys.stderr)
-                return Result.FAIL
-                ok = False
-
-            finally:
-                sh.close()
-
-            if ok:
-                return Result.OK
+        except Exception:
+            import traceback
+            traceback.print_exc(file=sys.stderr)
+            return Result.FAIL
+            ok = False
 
         finally:
-            if original_lines is None:
-                del os.environ['LINES']
-            else:
-                os.environ['LINES'] = original_lines
-            if original_columns is None:
-                del os.environ['COLUMNS']
-            else:
-                os.environ['COLUMNS'] = original_columns
+            sh.close()
 
-    def RunCase(self, shell_path, shell_label, func):
-        result = self.RunOnce(shell_path, shell_label, func)
+        if ok:
+            return Result.OK
+
+    def RunCase(self, shell_path, shell_label, func, test_params={}):
+        result = self.RunOnce(shell_path, shell_label, func, test_params)
 
         if result == Result.OK:
             return result, -1  # short circuit for speed
@@ -148,7 +171,8 @@ class TestRunner(object):
                 log('\tFAILED first time: Retrying 4 times')
                 for i in range(self.num_retries):
                     log('\tRetry %d of %d', i + 1, self.num_retries)
-                    result = self.RunOnce(shell_path, shell_label, func)
+                    result = self.RunOnce(shell_path, shell_label, func,
+                                          test_params)
                     if result == Result.OK:
                         num_success += 1
             else:
@@ -164,12 +188,17 @@ class TestRunner(object):
 
     def RunCases(self, cases, case_predicate, shell_pairs, result_table,
                  flaky):
-        for case_num, (desc, func, skip_shells,
-                       not_impl_shells) in enumerate(cases):
+        for case_num, (desc, func, skip_shells, not_impl_shells,
+                       needs_dimensions) in enumerate(cases):
             if not case_predicate(case_num, desc):
                 continue
 
             result_row = [case_num]
+
+            test_params = {}
+            if needs_dimensions:
+                test_params['num_lines'] = self.num_lines
+                test_params['num_columns'] = self.num_columns
 
             for shell_label, shell_path in shell_pairs:
                 skip_str = ''
@@ -195,7 +224,8 @@ class TestRunner(object):
                     flaky[case_num, shell_label] = -1
                     continue
 
-                result, retries = self.RunCase(shell_path, shell_label, func)
+                result, retries = self.RunCase(shell_path, shell_label, func,
+                                               test_params)
                 flaky[case_num, shell_label] = retries
 
                 result_row.append(result)
@@ -360,7 +390,7 @@ def main(argv):
 
     # List test cases and return
     if opts.do_list:
-        for i, (desc, _, _, _) in enumerate(CASES):
+        for i, (desc, *_) in enumerate(CASES):
             print('%d\t%s' % (i, desc))
         return
 

--- a/test/spec_lib.py
+++ b/test/spec_lib.py
@@ -179,6 +179,17 @@ def DefineStateful(p):
         dest='results_file',
         default=None,
         help='Write table of results to this file.  Default is stdout.')
+    # 24x80 (lines X columns) is the pexpect/ptyprocess default
+    p.add_option('--num-lines',
+                 dest='num_lines',
+                 type='int',
+                 default=24,
+                 help='Number of lines to emulate in terminal')
+    p.add_option('--num-columns',
+                 dest='num_columns',
+                 type='int',
+                 default=80,
+                 help='Number of columns to emulate in terminal')
 
 
 def DefineShSpec(p):

--- a/test/stateful.sh
+++ b/test/stateful.sh
@@ -55,7 +55,7 @@ job-control() {
 }
 
 bind() {
-  spec/stateful/bind.py $FIRST --oils-failures-allowed 4 "$@"
+  spec/stateful/bind.py $FIRST --oils-failures-allowed 4 --num-lines 24 --num-columns 80 "$@"
 }
 
 # Run on just 2 shells

--- a/test/stateful.sh
+++ b/test/stateful.sh
@@ -55,7 +55,7 @@ job-control() {
 }
 
 bind() {
-  spec/stateful/bind.py $FIRST --oils-failures-allowed 3 "$@"
+  spec/stateful/bind.py $FIRST --oils-failures-allowed 4 "$@"
 }
 
 # Run on just 2 shells

--- a/test/stateful.sh
+++ b/test/stateful.sh
@@ -55,7 +55,7 @@ job-control() {
 }
 
 bind() {
-  spec/stateful/bind.py $FIRST --oils-failures-allowed 2 "$@"
+  spec/stateful/bind.py $FIRST --oils-failures-allowed 3 "$@"
 }
 
 # Run on just 2 shells


### PR DESCRIPTION
# Summary

This adds automatic interactive tests of the READLINE_* env vars for `bind -x`.

# Changes
- Add dependency on [pyte](https://github.com/selectel/pyte), as suggested in the pexpect docs.
- Switch to raw r-strings for escaping to simplify and silence linter warnings
- Switch to single-character command sequences 
- Disable pexpect echoing in constructor instead of right afterwards with `setecho`
- Add LINES and COLUMNS environment variables for interactive tests, and associated `--num-lines` and `--num-columns` opts

# Areas I'd like feedback on

## Term Dimensions

In order to use pyte, it requires size params to emulate a terminal of given dimensions. pexpect defaults to 24 lines X 80 columns, which is fine, but it doesn't expose that anywhere (otherwise I would have used it).

How should we set, and share, the dimension info, which is needed by both pexpect and pyte?

### Alternatives
1. Hard-coding the dims everywhere - fragile, though tbf, it's unlikely pexpect would _ever_ change the defaults.
2. Add public height/width constants in `harness.py` - worked, but global state is ehhh...
3. Querying with tput instead of setting the dimensions - may or may not work under pyte, and might still break the tests if the dims were ever too small.
4. Set LINES and COLUMNS env vars before running each test fn - Mimics real shell vars, recommended [here](https://github.com/pexpect/pexpect/issues/587) as not all terminal apps use ioctl apparently.

I went with 4.  I'm not sold on the use of the LINES and COLUMNS env vars to communicate the dimensions to the interactive tests, but all the alternatives seemed worse.

I added the opts for the lines/columns in case anyone wanted to set them at a higher-level, but if you think that's unnecessary clutter, I can remove them.