### PR TITLE
docs: fix captureAll output strings

### DIFF
--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -976,7 +976,7 @@ Run a Command, and return its `stdout` string, `stderr` string, and integer
 `status`.
 
     var c = ^(echo out; echo err >&2)
-    var r = io.captureAll(c)  # => { stdout: "out", stderr: "err", status: 0 }
+    var r = io.captureAll(c)  # => {stdout: b'out\n', stderr: b'err\n', status: 0}
 
 It's similar to `io.captureStdout`, but returns more info.
 


### PR DESCRIPTION
The strings were missing `\n`! I also formatted it as if it was `= r` removing the spaces.