### PR TITLE
no-quotes.sh: set state back to oldstate

### DIFF
--- a/stdlib/osh/no-quotes.sh
+++ b/stdlib/osh/no-quotes.sh
@@ -43,10 +43,12 @@ nq-run() {
   local __status
 
   # Tricky: turn errexit off so we can capture it, but turn it on against
+  local oldstate
+  oldstate="$(set +o)"
   set +o errexit
   ( set -o errexit; "$@" )
   __status=$?
-  set -o errexit
+  set +vx; eval "$oldstate"
 
   out_status=$__status
 }
@@ -62,10 +64,12 @@ nq-capture() {
   local __stdout
 
   # Tricky: turn errexit off so we can capture it, but turn it on against
+  local oldstate
+  oldstate="$(set +o)"
   set +o errexit
   __stdout=$(set -o errexit; "$@")
   __status=$?
-  set -o errexit
+  set +vx; eval "$oldstate"
 
   out_status=$__status
   out_stdout=$__stdout
@@ -84,10 +88,12 @@ nq-capture-2() {
   local __stderr
 
   # Tricky: turn errexit off so we can capture it, but turn it on against
+  local oldstate
+  oldstate="$(set +o)"
   set +o errexit
   __stderr=$(set -o errexit; "$@" 2>&1)
   __status=$?
-  set -o errexit
+  set +vx; eval "$oldstate"
 
   out_status=$__status
   out_stderr=$__stderr
@@ -107,10 +113,12 @@ nq-redir() {
   local __stdout_file=$NQ_TEST_TEMP/nq-redir-$$.txt
 
   # Tricky: turn errexit off so we can capture it, but turn it on against
+  local oldstate
+  oldstate="$(set +o)"
   set +o errexit
   ( set -o errexit; "$@" ) > $__stdout_file
   __status=$?
-  set -o errexit
+  set +vx; eval "$oldstate"
 
   out_status=$__status
   out_stdout_file=$__stdout_file
@@ -127,10 +135,12 @@ nq-redir-2() {
   local __stderr_file=$NQ_TEST_TEMP/nq-redir-$$.txt
 
   # Tricky: turn errexit off so we can capture it, but turn it on against
+  local oldstate
+  oldstate="$(set +o)"
   set +o errexit
   ( set -o errexit; "$@" ) 2> $__stderr_file
   __status=$?
-  set -o errexit
+  set +vx; eval "$oldstate"
 
   out_status=$__status
   out_stderr_file=$__stderr_file


### PR DESCRIPTION
In osh we can't assume errexit is always enabled.

So we set oldstate afterwards again (and disable the verbose trace of this operation in case it was enabled).