### PR TITLE
[deps] Add more required wedge dependencies for Alpine

### DIFF
--- a/build/deps.sh
+++ b/build/deps.sh
@@ -161,6 +161,8 @@ readonly -a WEDGE_DEPS_DEBIAN=(
 )
 
 readonly -a WEDGE_DEPS_ALPINE=(
+  coreutils findutils
+
   bzip2
   xz
 


### PR DESCRIPTION
Running the one-time setup does not currently work on a fresh Alpine install.

Currently, "coreutils" is needed for some advanced usage of "xargs". "findutils" is needed for some advanced usage of "date".