### PR TITLE
args.ysh: Add support for flag escaping via --

### DIFF
--- a/doc/ref/chap-stdlib.md
+++ b/doc/ref/chap-stdlib.md
@@ -422,6 +422,12 @@ specification. For example, if it's missing a required positional argument:
     var args = parseArgs(spec, [])
     # => raises an error about the missing 'path' (status = 2)
 
+The special argument `--` can be used to bypass flag processing for all
+remaining arguments - effectively escaping flags that might be shared between
+the parser `spec` and a wrapped command. This is a commonly used technique to
+pass arguments through to a command. All arguments after `--` will be captured
+in `rest`. It is an error to use `--` when `rest` is not defined in `spec`.
+
 <!--
 TODO: Document chaining parsers / sub-commands
       - Either will allow parser nesting

--- a/stdlib/ysh/args-test.ysh
+++ b/stdlib/ysh/args-test.ysh
@@ -380,6 +380,9 @@ proc test-escaped-args {
 
   try { call parseArgs(spec, :|-f 1.0 pos_arg -- -i foo bar|) }
   assert [2 === _error.code]
+  # still an error when no args follow `--`
+  try { call parseArgs(spec, :|-i --|) }
+  assert [2 === _error.code]
 }
 
 if is-main {

--- a/stdlib/ysh/args-test.ysh
+++ b/stdlib/ysh/args-test.ysh
@@ -357,15 +357,15 @@ proc test-escaped-args {
 
   var args = parseArgs(spec, :|-f 1.0 pos_arg -- -i foo bar|)
 
-  assert [type(args.float) === 'Float']
+  assert ['Float' === type(args.float)]
   assert [floatsEqual(args.float, 1.0)]
-  assert [args.int === null]
-  assert [args.pos === 'pos_arg']
-  assert [type(args.rest) === 'List']
-  assert [len(args.rest) === 3]
-  assert [args.rest[0] === '-i']
-  assert [args.rest[1] === 'foo']
-  assert [args.rest[2] === 'bar']
+  assert [null === args.int]
+  assert ['pos_arg' === args.pos]
+  assert ['List' === type(args.rest)]
+  assert [3 === len(args.rest)]
+  assert ['-i' === args.rest[0]]
+  assert ['foo' === args.rest[1]]
+  assert ['bar' === args.rest[2]]
 
   # positional args are still required
   try { call parseArgs(spec, :|-f 1.0 -- -i foo bar|) }

--- a/stdlib/ysh/args-test.ysh
+++ b/stdlib/ysh/args-test.ysh
@@ -347,6 +347,41 @@ proc test-multi-value-flags {
   assert [2 === _error.code]
 }
 
+proc test-escaped-args {
+  parser (&spec) {
+    flag -f --float (Float)
+    flag -i --int (Int)
+    arg pos
+    rest rest
+  }
+
+  var args = parseArgs(spec, :|-f 1.0 pos_arg -- -i foo bar|)
+
+  assert [type(args.float) === 'Float']
+  assert [floatsEqual(args.float, 1.0)]
+  assert [args.int === null]
+  assert [args.pos === 'pos_arg']
+  assert [type(args.rest) === 'List']
+  assert [len(args.rest) === 3]
+  assert [args.rest[0] === '-i']
+  assert [args.rest[1] === 'foo']
+  assert [args.rest[2] === 'bar']
+
+  # positional args are still required
+  try { call parseArgs(spec, :|-f 1.0 -- -i foo bar|) }
+  assert [2 === _error.code]
+
+  # it's an error to provide `--` without `rest`
+  parser (&spec) {
+    flag -f --float (Float)
+    flag -i --int (Int)
+    arg pos
+  }
+
+  try { call parseArgs(spec, :|-f 1.0 pos_arg -- -i foo bar|) }
+  assert [2 === _error.code]
+}
+
 if is-main {
   byo-maybe-run
 }

--- a/stdlib/ysh/args.ysh
+++ b/stdlib/ysh/args.ysh
@@ -165,9 +165,19 @@ func parseArgs(spec, argv) {
 
   var value
   var found
+  var escape_remaining = false
   while (i < argc) {
     var arg = argv[i]
-    if (arg.startsWith('-')) {
+
+    if (escape_remaining) {
+      if (not spec.rest) {
+        error "Too many arguments, unexpected '$arg'" (code=2)
+      }
+
+      call rest->append(arg)
+    } elif (arg === '--') {
+      setvar escape_remaining = true
+    } elif (arg.startsWith('-')) {
       setvar found = false
 
       for flag in (spec.flags) {

--- a/stdlib/ysh/args.ysh
+++ b/stdlib/ysh/args.ysh
@@ -170,12 +170,12 @@ func parseArgs(spec, argv) {
     var arg = argv[i]
 
     if (escape_remaining) {
-      if (not spec.rest) {
-        error "Too many arguments, unexpected '$arg'" (code=2)
-      }
-
       call rest->append(arg)
     } elif (arg === '--') {
+      if (not spec.rest) {
+        error "Unexpected '--' argument - extraneous positional arguments are prohibited" (code=2)
+      }
+
       setvar escape_remaining = true
     } elif (arg.startsWith('-')) {
       setvar found = false


### PR DESCRIPTION
Ref: [#oil-dev > A missing feature in args.ysh?](https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/A.20missing.20feature.20in.20args.2Eysh.3F/with/526243441)