### PR TITLE
[builtin/assign_osh] Do not print variable name for unknown types

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -196,7 +196,7 @@ def _PrintVariables(
                 ["=", bash_impl.BashArray_ToStrForShellPrint(sparse_val)])
 
         else:
-            pass  # note: other types silently ignored
+            continue  # note: other types silently ignored
 
         print(''.join(decl))
         count += 1

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -731,6 +731,19 @@ typeset -Ar dict2
 ## N-I dash/mksh status: 99
 ## N-I dash/mksh stdout-json: ""
 
+#### "var d = {}; declare -p d" does not print anything (OSH)
+case $SH in (bash-4.4|dash|mksh|zsh) exit 99;; esac
+
+# We pretend that the variable does not exist when the variable is not
+# representable with the "declare -p" format.
+
+var d = {}
+declare -p d
+## STDOUT:
+## END
+## status: 1
+## N-I bash/dash/mksh/zsh status: 99
+
 #### readonly array should not be modified by a+=(1)
 case $SH in (dash) exit 99;; esac # dash/mksh does not support associative arrays
 


### PR DESCRIPTION
From private communication:

> While checking one of my WIP branches, I noticed that var d = {}; declare -p d produces declare -- d, which appears to be an unset value of the variable d. This is an intersection area of OSH and YSH, so this isn't a copatibility issue, but I'm not sure if the current design makes sense. What do you think?
>
> Andy Chu: Oh yes, I think I noticed that too
> I think we could "pretend d doesn't exist"?  Just not print itAndy Chu: Because there is no way to express it with the declare -p syntax ...
