### PR TITLE
[osh/word_eval] Fix word-splitting bugs

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -1570,7 +1570,8 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
                     if quoted and nullary_op.id == Id.VOp3_Star:
                         sep = self.splitter.GetJoinChar()
-                        part_vals.append(Piece(sep.join(names), quoted, True))
+                        part_vals.append(
+                            Piece(sep.join(names), quoted, not quoted))
                     else:
                         part_vals.append(part_value.Array(names, quoted))
                     return  # EARLY RETURN
@@ -1601,7 +1602,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 val = self._ProcessUndef(val, part.name_tok, vsub_state)
 
                 n = self._Count(val, part.name_tok)
-                part_vals.append(Piece(str(n), quoted, False))
+                part_vals.append(Piece(str(n), quoted, not quoted))
                 return  # EARLY EXIT: nothing else can come after length
 
             elif part.prefix_op.id == Id.VSub_Bang:
@@ -1849,7 +1850,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
                 part = cast(Token, UP_part)
                 # Split if it's in a substitution.
                 # That is: echo is not split, but ${foo:-echo} is split
-                v = Piece(lexer.LazyStr(part), quoted, is_subst)
+                v = Piece(lexer.LazyStr(part), quoted, not quoted and is_subst)
                 part_vals.append(v)
 
             elif case(word_part_e.BracedRangeDigit):

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -861,3 +861,52 @@ for i in ""$A""; do echo =$i=; done
 =def=
 ==
 ## END
+
+
+#### Regression: "${!v*}"x should not be split
+case $SH in dash|mksh|ash|yash) exit 99;; esac
+IFS=x
+axb=1
+echo "${!axb*}"
+echo "${!axb*}"x
+## STDOUT:
+axb
+axbx
+## END
+## N-I dash/mksh/ash/yash status: 99
+## N-I dash/mksh/ash/yash STDOUT:
+## END
+
+
+#### Regression: ${!v} should be split
+v=hello
+IFS=5
+echo ${#v}
+echo "${#v}"
+## STDOUT:
+
+5
+## END
+
+
+#### Regression: "${v:-AxBxC}"x should not be split
+IFS=x
+v=
+echo "${v:-AxBxC}"
+echo "${v:-AxBxC}"x  # <-- osh failed this
+echo ${v:-AxBxC}
+echo ${v:-AxBxC}x
+echo ${v:-"AxBxC"}
+echo ${v:-"AxBxC"}x
+echo "${v:-"AxBxC"}"
+echo "${v:-"AxBxC"}"x
+## STDOUT:
+AxBxC
+AxBxCx
+A B C
+A B Cx
+AxBxC
+AxBxCx
+AxBxC
+AxBxCx
+## END


### PR DESCRIPTION
Bug 1: word splitting is applied to `${!prefix*}` inside quoted string `"..."`

```console
$ bash -c 'IFS=x axb=1; echo "${!axb*}"x'
axbx
$ bin/osh -c 'IFS=x axb=1; echo "${!axb*}"x'
a bx
```

Bug 2: word splitting is not applied to `${#v}`

```console
$ bash -c 'IFS=5 v=hello; echo [${#v}]'
[ ]
$ bin/osh -c 'IFS=5 v=hello; echo [${#v}]'
[5]
```

Bug 3: word splitting is applied to `${v:-val}` inside quoted string `"..."`

```console
$ bash -c 'IFS=x v=; echo "${v:-axb}"x'
axbx
$ bin/osh -c 'IFS=x v=; echo "${v:-axb}"x'
a bx
```