### PR TITLE
[osh/word_eval] Fix behaviors of `\` in unquoted substitutions

### DIFF
--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh ash yash
-## oils_failures_allowed: 7
+## oils_failures_allowed: 6
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.


### PR DESCRIPTION
This PR fixes glob quoting issues.

Bug 1: `'a\b'` shouldn't become `'a\\b'`.

```console
$ bash -c 'v="a\\b"; set -f; echo *$v'
*a\b
$ bin/osh -c 'v="a\\b"; set -f; echo *$v'
*a\\b
```

Bash behavior: `\` should escape the next glob chars in unquoted substitutions, and the single `\` should not match the literal `\`.

```bash
$ mkdir x; touch 'x/a\b' 'x/ab*'
$ bash -c 'v="*\*"; echo x/$v'
x/ab*
$ bin/osh -c 'v="*\*"; echo x/$v'
x/a\b
```
