### PR TITLE
[builtin/read_osh] read -n respects backslashes when not -r, and other fixes

### DIFF
--- a/builtin/read_osh.py
+++ b/builtin/read_osh.py
@@ -145,8 +145,8 @@ def _ReadN(num_bytes, cmd_ev):
     return ''.join(chunks)
 
 
-def _ReadPortion(delim_byte, max_chars, cmd_ev):
-    # type: (int, int, CommandEvaluator) -> Tuple[str, bool]
+def _ReadPortion(delim_byte, max_chars, allow_escape, cmd_ev):
+    # type: (int, int, bool, CommandEvaluator) -> Tuple[str, bool]
     """Read a portion of stdin.
 
     Reads until delimiter or max_chars, which ever comes first. Will ignore
@@ -157,9 +157,10 @@ def _ReadPortion(delim_byte, max_chars, cmd_ev):
     ch_array = []  # type: List[int]
     eof = False
 
-    bytes_read = 0
+    chars_read = 0
+    backslash = False
     while True:
-        if max_chars >= 0 and bytes_read >= max_chars:
+        if max_chars >= 0 and chars_read >= max_chars:
             break
 
         ch, err_num = pyos.ReadByte(0)
@@ -174,6 +175,16 @@ def _ReadPortion(delim_byte, max_chars, cmd_ev):
             eof = True
             break
 
+        elif backslash:
+            backslash = False
+            if ch == pyos.NEWLINE_CH:
+                continue
+            ch_array.append(pyos.BACKSLASH_CH)
+            ch_array.append(ch)
+        elif allow_escape and ch == pyos.BACKSLASH_CH:
+            backslash = True
+            continue
+
         elif ch == delim_byte:
             break
 
@@ -184,7 +195,7 @@ def _ReadPortion(delim_byte, max_chars, cmd_ev):
         else:
             ch_array.append(ch)
 
-        bytes_read += 1
+        chars_read += 1
 
     return pyutil.ChArrayToString(ch_array), eof
 
@@ -496,28 +507,22 @@ class Read(vm._Builtin):
 
         # Read MORE THAN ONE line for \ line continuation (and not read -r)
         parts = []  # type: List[mylib.BufWriter]
-        join_next = False
-        status = 0
-        while True:
-            chunk, eof = _ReadPortion(delim_byte, mops.BigTruncate(arg.n),
+        chunk, eof = _ReadPortion(delim_byte, mops.BigTruncate(arg.n), not raw,
                                       self.cmd_ev)
 
-            if eof:
-                # status 1 to terminate loop.  (This is true even though we set
-                # variables).
-                status = 1
+        # status 1 to terminate loop.  (This is true even though we set
+        # variables).
+        status = 1 if eof else 0
 
-            #log('LINE %r', chunk)
-            if len(chunk) == 0:
-                break
-
+        #log('LINE %r', chunk)
+        if len(chunk) > 0:
+            join_next = False
             spans = self.splitter.SplitForRead(chunk, not raw, do_split)
             done, join_next = _AppendParts(chunk, spans, max_results,
                                            join_next, parts)
 
             #log('PARTS %s continued %s', parts, continued)
-            if done:
-                break
+            assert done
 
         entries = [buf.getvalue() for buf in parts]
         num_parts = len(entries)

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -174,11 +174,11 @@ class ProcessTest(_Common):
 
         err_out = []
         self.fd_state.Push([r], err_out)
-        line1, _ = read_osh._ReadPortion(pyos.NEWLINE_CH, -1, cmd_ev)
+        line1, _ = read_osh._ReadPortion(pyos.NEWLINE_CH, -1, False, cmd_ev)
         self.fd_state.Pop(err_out)
 
         self.fd_state.Push([r], err_out)
-        line2, _ = read_osh._ReadPortion(pyos.NEWLINE_CH, -1, cmd_ev)
+        line2, _ = read_osh._ReadPortion(pyos.NEWLINE_CH, -1, False, cmd_ev)
         self.fd_state.Pop(err_out)
 
         # sys.stdin.readline() would erroneously return 'two' because of buffering.

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -28,6 +28,7 @@ _ = log
 
 EOF_SENTINEL = 256  # bigger than any byte
 NEWLINE_CH = 10  # ord('\n')
+BACKSLASH_CH = 92  # \
 
 
 def FlushStdout():

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -21,6 +21,7 @@ const int TERM_ICANON = ICANON;
 const int TERM_ECHO = ECHO;
 const int EOF_SENTINEL = 256;
 const int NEWLINE_CH = 10;
+const int BACKSLASH_CH = 92;
 
 Tuple2<int, int> WaitPid(int waitpid_options);
 Tuple2<int, int> Read(int fd, int n, List<BigStr*>* chunks);

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -779,7 +779,11 @@ Flags:
 
     -a ARRAY  assign the tokens to elements of this array
     -d CHAR   use DELIM as delimiter, instead of newline
-    -n NUM    read up to NUM characters, respecting delimiters
+    -n NUM    read up to NUM characters, respecting delimiters. When -r is not
+              specified, backslash escape of the form "\?" is counted as one
+              character. This is the Bash behavior, but other shells such as
+              ash and mksh count the number of bytes with "-n" without
+              considering backslash escaping.
     -p STR    print the string PROMPT before reading input
     -r        raw mode: don't let backslashes escape characters
     -s        silent: do not echo input coming from a terminal


### PR DESCRIPTION
Bug: `read -n 4` should not repeat `_ReadPortion` even if the previous read ended with incomplete backslash

```console
$ bash -c 'echo "abc\def\ghijxxxx" | (read -n 4; declare -p REPLY)'
declare -- REPLY="abcd"
$ bin/osh -c 'echo "abc\def\ghijxxxx" | (read -n 4; declare -p REPLY)'
declare -- REPLY=abcdefghij
```

Bash behavior: Counting of `read -n 5` should exclude escaping backslash

```console
$ bash -c 'echo "a\b\c\d\exxxx" | (read -n 5; declare -p REPLY)'
declare -- REPLY="abcde"
$ bin/osh -c 'echo "a\b\c\d\exxxx" | (read -n 5; declare -p REPLY)'
declare -- REPLY=abc
```