### PR TITLE
Evaluate command.Simple argv before redirects

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -863,11 +863,8 @@ class ShellExecutor(vm._Executor):
                 # Change it to builtin cat < file.
                 # Blame < because 'builtin cat' has no location
                 blame_tok = redir_node.redirects[0].op
-                simple = command.Simple(blame_tok, [], self.builtin_cat_words,
-                                        None, None, False, None)  # TODO: Is this correct? Or do we need to make the entire `node` a `command.Simple` too?
-
-                # MUTATE redir node so it's like $(<file _cat)
-                redir_node.child = simple
+                node = command.Simple(blame_tok, [], self.builtin_cat_words,
+                                        None, None, False, redir_node.redirects)
 
         status, stdout_str = self.CaptureStdout(node)
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -864,7 +864,7 @@ class ShellExecutor(vm._Executor):
                 # Blame < because 'builtin cat' has no location
                 blame_tok = redir_node.redirects[0].op
                 simple = command.Simple(blame_tok, [], self.builtin_cat_words,
-                                        None, None, False)
+                                        None, None, False, None)  # TODO: Is this correct? Or do we need to make the entire `node` a `command.Simple` too?
 
                 # MUTATE redir node so it's like $(<file _cat)
                 redir_node.child = simple

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -422,7 +422,10 @@ module syntax
            List[word] words,
            ArgList? typed_args, LiteralBlock? block,
            # is_last_cmd is used for fork() optimizations
-           bool is_last_cmd)
+           bool is_last_cmd,
+           # (#2307) Simple command redirects, unlike all others, are evaluated
+           # *after* the argv word list
+           List[Redir] redirects)
 
     # This doesn't technically belong in the LST, but it's convenient for
     # execution

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -362,7 +362,7 @@ module syntax
 
   for_iter =
     Args                          # for x; do echo $x; done # implicit "$@"
-  | Words(List[word] words)       # for x in 'foo' *.py { echo $x }
+  | Words(List[word] words)       # for x in 'foo' *.py { echo $x }S
                                   # like YshArrayLiteral, but no location for %(
   | YshExpr(expr e, Token blame)  # for x in (mylist) { echo $x }
   #| Files(Token left, List[word] words)
@@ -423,9 +423,10 @@ module syntax
            ArgList? typed_args, LiteralBlock? block,
            # is_last_cmd is used for fork() optimizations
            bool is_last_cmd,
-           # (#2307) Simple command redirects, unlike all others, are evaluated
-           # *after* the argv word list
-           List[Redir] redirects)
+           # (#2307) Redirects on simple commands are evaluated
+           # AFTER the argv word list, unlike all other commands.
+           # This field is null if there are no redirects
+           List[Redir]? redirects)
 
     # This doesn't technically belong in the LST, but it's convenient for
     # execution

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1090,13 +1090,10 @@ class CommandEvaluator(object):
 
         run_flags = executor.IS_LAST_CMD if node.is_last_cmd else 0
 
-        #print('n', node.redirects)
         status, redirects, io_errors = self._DoRedirects(node.redirects or [])
-        #print(status, redirects, io_errors)
         if status != 0:
             return status
 
-        #print(redirects)
         with vm.ctx_Redirect(self.shell_ex, len(redirects), io_errors):
             # NOTE: RunSimpleCommand may never return
             if len(node.more_env):  # I think this guard is necessary?

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1090,7 +1090,7 @@ class CommandEvaluator(object):
 
         run_flags = executor.IS_LAST_CMD if node.is_last_cmd else 0
 
-        status = self._DoRedirects(node.redirects)
+        status = self._EvalAndPushRedirects(node.redirects)
         if status != 0:
             return status
 
@@ -1740,7 +1740,7 @@ class CommandEvaluator(object):
 
         return status
 
-    def _DoRedirects(self, redirects):
+    def _EvalAndPushRedirects(self, redirects):
         # type: (List[Redir]) -> int
         if redirects is None:
             return 0
@@ -1787,7 +1787,7 @@ class CommandEvaluator(object):
 
     def _DoRedirect(self, node, cmd_st):
         # type: (command.Redirect, CommandStatus) -> int
-        status = self._DoRedirects(node.redirects)
+        status = self._EvalAndPushRedirects(node.redirects)
         if status != 0:
             return status
 

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1090,7 +1090,7 @@ class CommandEvaluator(object):
 
         run_flags = executor.IS_LAST_CMD if node.is_last_cmd else 0
 
-        status, redirects, io_errors = self._DoRedirects(node.redirects or [])
+        status, redirects, io_errors = self._DoRedirects(node.redirects if node.redirects is not None else [])
         if status != 0:
             return status
 
@@ -1736,7 +1736,7 @@ class CommandEvaluator(object):
         return status
 
     def _DoRedirects(self, redirects_):
-        # type: (List[Redir]) -> int
+        # type: (List[Redir]) -> Tuple[int, List[RedirValue], List[error.IOError_OSError]]
 
         status = 0
         redirects = []  # type: List[RedirValue]

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -386,7 +386,7 @@ def _MakeSimpleCommand(
     more_env = []  # type: List[EnvPair]
     _AppendMoreEnv(preparsed_list, more_env)
 
-    if not len(redirects):
+    if len(redirects) == 0:
         redirects = None
 
     # is_last_cmd is False by default

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -349,6 +349,7 @@ def _MakeSimpleCommand(
         suffix_words,  # type: List[CompoundWord]
         typed_args,  # type: Optional[ArgList]
         block,  # type: Optional[LiteralBlock]
+        redirects,  # type: List[Redir]
 ):
     # type: (...) -> command.Simple
     """Create a command.Simple"""
@@ -385,9 +386,12 @@ def _MakeSimpleCommand(
     more_env = []  # type: List[EnvPair]
     _AppendMoreEnv(preparsed_list, more_env)
 
+    if not len(redirects):
+        redirects = None
+
     # is_last_cmd is False by default
     return command.Simple(blame_tok, more_env, words3, typed_args, block,
-                          False)
+                          False, redirects)
 
 
 class VarChecker(object):
@@ -1336,12 +1340,8 @@ class CommandParser(object):
         # TODO: check that we don't have env1=x x[1]=y env2=z here.
 
         # FOO=bar printenv.py FOO
-        node = _MakeSimpleCommand(preparsed_list, suffix_words, typed_args,
-                                  block)
-        if len(redirects):
-            return command.Redirect(node, redirects)
-        else:
-            return node
+        return _MakeSimpleCommand(preparsed_list, suffix_words, typed_args,
+                                  block, redirects)
 
     def ParseBraceGroup(self):
         # type: () -> BraceGroup

--- a/osh/cmd_parse_test.py
+++ b/osh/cmd_parse_test.py
@@ -125,16 +125,14 @@ class SimpleCommandTest(unittest.TestCase):
         node = assertParseSimpleCommand(
             self, 'FOO=bar >output.txt SPAM=eggs ls foo')
         self.assertEqual(1, len(node.redirects))
-
-        self.assertEqual(2, len(node.child.words))
-        self.assertEqual(2, len(node.child.more_env))
+        self.assertEqual(2, len(node.words))
+        self.assertEqual(2, len(node.more_env))
 
         node = assertParseSimpleCommand(
             self, 'FOO=bar >output.txt SPAM=eggs ls foo >output2.txt')
         self.assertEqual(2, len(node.redirects))
-
-        self.assertEqual(2, len(node.child.words))
-        self.assertEqual(2, len(node.child.more_env))
+        self.assertEqual(2, len(node.words))
+        self.assertEqual(2, len(node.more_env))
 
     def testMultipleGlobalShAssignments(self):
         node = assert_ParseCommandList(self, 'ONE=1 TWO=2')
@@ -151,21 +149,17 @@ class SimpleCommandTest(unittest.TestCase):
 
     def testParseRedirectInTheMiddle(self):
         node = assert_ParseCommandList(self, 'echo >out.txt 1 2 3')
-        self.assertEqual(command_e.Redirect, node.tag())
+        self.assertEqual(command_e.Simple, node.tag())
         self.assertEqual(1, len(node.redirects))
-
-        self.assertEqual(command_e.Simple, node.child.tag())
-        self.assertEqual(4, len(node.child.words))
+        self.assertEqual(4, len(node.words))
 
     def testParseRedirectBeforeShAssignment(self):
         # Write ENV to a file
         node = assert_ParseCommandList(self, '>out.txt PYTHONPATH=. env')
-        self.assertEqual(command_e.Redirect, node.tag())
+        self.assertEqual(command_e.Simple, node.tag())
         self.assertEqual(1, len(node.redirects))
-
-        self.assertEqual(command_e.Simple, node.child.tag())
-        self.assertEqual(1, len(node.child.words))
-        self.assertEqual(1, len(node.child.more_env))
+        self.assertEqual(1, len(node.words))
+        self.assertEqual(1, len(node.more_env))
 
     def testParseAdjacentDoubleQuotedWords(self):
         node = assertParseSimpleCommand(self,
@@ -268,7 +262,7 @@ EOF
 \tEOF
 echo hi
 """)
-        self.assertEqual(node.tag(), command_e.Redirect)
+        self.assertEqual(node.tag(), command_e.Simple)
         assertHereDocToken(self, 'one tab then foo: ', node)
 
     def testHereDocInPipeline(self):
@@ -390,7 +384,7 @@ echo 3) 4
 EOF
 """)
         self.assertEqual(1, len(node.redirects))
-        self.assertEqual(1, len(node.child.words))
+        self.assertEqual(1, len(node.words))
 
 
 class ArrayTest(unittest.TestCase):
@@ -428,11 +422,11 @@ class RedirectTest(unittest.TestCase):
     def testParseRedirects1(self):
         node = assertParseSimpleCommand(self, '>out.txt cat 1>&2')
         self.assertEqual(2, len(node.redirects))
-        self.assertEqual(1, len(node.child.words))
+        self.assertEqual(1, len(node.words))
 
         node = assertParseSimpleCommand(self, ' cat <&3')
         self.assertEqual(1, len(node.redirects))
-        self.assertEqual(1, len(node.child.words))
+        self.assertEqual(1, len(node.words))
 
     def testParseFilenameRedirect(self):
         node = assertParseRedirect(self, '>out.txt cat')
@@ -468,7 +462,7 @@ hi
 EOF
 """)
         self.assertEqual(2, len(node.redirects))
-        self.assertEqual(1, len(node.child.words))
+        self.assertEqual(1, len(node.words))
 
     def testClobberRedirect(self):
         node = assertParseSimpleCommand(self, 'echo hi >| clobbered.txt')
@@ -546,7 +540,7 @@ class CommandParserTest(unittest.TestCase):
 
     def test_ParseCommandLine(self):
         node = assert_ParseCommandLine(self, 'ls foo 2>/dev/null')
-        self.assertEqual(2, len(node.child.words))
+        self.assertEqual(2, len(node.words))
 
         node = assert_ParseCommandLine(self, 'ls foo|wc -l')
         self.assertEqual(command_e.Pipeline, node.tag())

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -593,9 +593,10 @@ global
 ['loc', 'global', 'loc']
 ## END
 
-#### redirect after assignment builtin (what's going on with dash/bash/mksh here?)
+#### redirect after assignment builtin (eval redirects after evaluating arguments)
 
-# TODO: update title -- this is related to redirect evaluation order!
+# See also: spec/redir-order.test.sh (#2307)
+# The $(stdout_stderr.py) is evaluated *before* the 2>/dev/null redirection
 
 readonly x=$(stdout_stderr.py) 2>/dev/null
 echo done

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 2
+## oils_failures_allowed: 0
 ## compare_shells: dash bash-4.4 mksh zsh
 
 #### Env value doesn't persist
@@ -594,6 +594,9 @@ global
 ## END
 
 #### redirect after assignment builtin (what's going on with dash/bash/mksh here?)
+
+# TODO: update title -- this is related to redirect evaluation order!
+
 readonly x=$(stdout_stderr.py) 2>/dev/null
 echo done
 ## STDOUT:

--- a/spec/redir-order.test.sh
+++ b/spec/redir-order.test.sh
@@ -2,6 +2,8 @@
 
 #### echo `cat OSCFLAGS` "world" > OSCFLAGS (from Alpine imap)
 
+# strace --follow-forks --trace=openat $0 --ast-format text -nc 'echo hello > OSCFLAGS'
+# strace --follow-forks --trace=openat $0 -c 'echo hello > OSCFLAGS'
 echo hello > OSCFLAGS
 #strace --follow-forks --trace=openat $0 -c 'echo `cat OSCFLAGS` "world" > OSCFLAGS'
 echo `cat OSCFLAGS` "world" > OSCFLAGS

--- a/spec/redir-order.test.sh
+++ b/spec/redir-order.test.sh
@@ -3,12 +3,30 @@
 #### echo `cat OSCFLAGS` "world" > OSCFLAGS (from Alpine imap)
 
 echo hello > OSCFLAGS
+#strace --follow-forks --trace=openat $0 -c 'echo `cat OSCFLAGS` "world" > OSCFLAGS'
 echo `cat OSCFLAGS` "world" > OSCFLAGS
 #echo $(cat OSCFLAGS) "world" > OSCFLAGS
 cat OSCFLAGS
 
 ## STDOUT:
 hello world
+## END
+
+#### 2 echo `cat OSCFLAGS` "world" > OSCFLAGS (from Alpine imap)
+
+echo hello > OSCFLAGS
+(echo `cat OSCFLAGS` "world") > OSCFLAGS
+cat OSCFLAGS
+
+echo hello > OSCFLAGS
+for x in 1 2 3; do echo `cat OSCFLAGS` "world"; done > OSCFLAGS
+cat OSCFLAGS
+
+## STDOUT:
+world
+world
+world world
+world world world world
 ## END
 
 #### for word + redirect order

--- a/spec/redir-order.test.sh
+++ b/spec/redir-order.test.sh
@@ -1,11 +1,8 @@
-## oils_failures_allowed: 1
+## oils_failures_allowed: 0
 
 #### echo `cat OSCFLAGS` "world" > OSCFLAGS (from Alpine imap)
 
-# strace --follow-forks --trace=openat $0 --ast-format text -nc 'echo hello > OSCFLAGS'
-# strace --follow-forks --trace=openat $0 -c 'echo hello > OSCFLAGS'
 echo hello > OSCFLAGS
-#strace --follow-forks --trace=openat $0 -c 'echo `cat OSCFLAGS` "world" > OSCFLAGS'
 echo `cat OSCFLAGS` "world" > OSCFLAGS
 #echo $(cat OSCFLAGS) "world" > OSCFLAGS
 cat OSCFLAGS
@@ -14,21 +11,14 @@ cat OSCFLAGS
 hello world
 ## END
 
-#### 2 echo `cat OSCFLAGS` "world" > OSCFLAGS (from Alpine imap)
+#### subshell + redirect order
 
 echo hello > OSCFLAGS
 (echo `cat OSCFLAGS` "world") > OSCFLAGS
 cat OSCFLAGS
 
-echo hello > OSCFLAGS
-for x in 1 2 3; do echo `cat OSCFLAGS` "world"; done > OSCFLAGS
-cat OSCFLAGS
-
 ## STDOUT:
 world
-world
-world world
-world world world world
 ## END
 
 #### for word + redirect order

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -10,7 +10,7 @@ abc=${a?bc} echo hello; echo blah
 ## stdout-json: ""
 
 #### setting readonly var (bash is only one where it's non-fatal)
-# https://landley.net/notes-2020.html#12-06-2020
+# https://landley.net/notes-2020.html#20-06-2020
 
 readonly abc=123
 abc=def

--- a/spec/toysh-posix.test.sh
+++ b/spec/toysh-posix.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 5
+## oils_failures_allowed: 4
 ## compare_shells: bash dash mksh zsh ash yash
 
 #### Fatal error
@@ -10,7 +10,7 @@ abc=${a?bc} echo hello; echo blah
 ## stdout-json: ""
 
 #### setting readonly var (bash is only one where it's non-fatal)
-# http://landley.net/notes.html#20-06-2020
+# https://landley.net/notes-2020.html#12-06-2020
 
 readonly abc=123
 abc=def

--- a/tools/ysh_ify.py
+++ b/tools/ysh_ify.py
@@ -761,6 +761,10 @@ class YshPrinter(object):
 
                 self._DoSimple(node, local_symbols)
 
+                if node.redirects is not None:
+                    for r in node.redirects:
+                        self.DoRedirect(r, local_symbols)
+
             elif case(command_e.ShAssignment):
                 node = cast(command.ShAssignment, UP_node)
 


### PR DESCRIPTION
Fixes: https://github.com/oils-for-unix/oils/issues/2307

Need to clean-up a bit more, but this should fix the issue. Want to check its impact on other tests first.

---

### TODO List

- [x] Make CI Green
- [x] Clean-up the fix
  - [x] Address/test TODO comments
  - [x] Can we reduce return value count in `_DoRedirects`? (also could have a better name)
  - [ ] Cleaner way to report the `io_errors` in `_DoSimple` and `_DoRedirect`