### PR TITLE
Use `mktemp -d` when possible in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -15,7 +15,7 @@
 # - Other settings: LTO, PGO?  Consider moving prefix, LTO, PGO to build and
 #   install steps.
 
-TMP=${TMPDIR:-/tmp}  # Assume that any system has $TMPDIR set or /tmp exists
+TMP="$(mktemp -d || echo "${TMPDIR:-/tmp}")"
 readonly TMP  # POSIX sh supports 'readonly'
 
 log() {


### PR DESCRIPTION
Because `mktemp -d` is near universally supported by Unix-likes, use it to create a random per-execution directory under ${TMPDIR:-/tmp}. This closes the vector for a well-known attack where pre-known filepaths in /tmp are modified. Before this change, the caller would need to set TMPDIR manually to avoid the risk.

Ref: [#oil-dev > temp dir provisioning in configure script](https://oilshell.zulipchat.com/#narrow/channel/121539-oil-dev/topic/temp.20dir.20provisioning.20in.20configure.20script)