### PR TITLE
Add more spec tests for history builtin and associated envvars

### DIFF
--- a/spec/builtin-history.test.sh
+++ b/spec/builtin-history.test.sh
@@ -1,5 +1,7 @@
 ## tags: interactive
 ## compare_shells: bash
+## oils_failures_allowed: 8
+## oils_cpp_failures_allowed: 7
 
 #### history -a
 rm -f tmp
@@ -32,28 +34,64 @@ history -a
 ^D
 ## END
 
-#### history -r
-rm -f tmp
-echo 'foo' > tmp
 
-echo '
+#### history -w
+
+cd $TMP
+echo 'cmd orig' > tmp
+HISTFILE=tmp
+history -c
+echo 'cmd new' > /dev/null
+history -w
+grep 'orig' tmp > /dev/null
+echo "found=$?"
+## STDOUT:
+found=1
+## END
+
+
+#### history -r 
+# Reads from the history file, and appends it to the current history
+
+cd $TMP
+printf "cmd orig%s\n" {1..10} > tmp
+HISTFILE=tmp
+
 history -c
 
-HISTFILE=tmp
 history -r
-history
-' | $SH -i
+history -r
 
-# match osh's behaviour of echoing ^D for EOF
-case $SH in bash) echo '^D' ;; esac
+history | grep orig | wc -l
 
 ## STDOUT:
-    1  HISTFILE=tmp
-    2  history -r
-    3  foo
-    4  history
-^D
+20
 ## END
+
+
+#### history -n
+# Reads new commands from the history file, and appends them to the current history
+# Based on line ranges, not contents
+
+cd $TMP
+
+printf "cmd orig%s\n" {1..10} > tmp1
+cp tmp1 tmp2
+printf "cmd new%s\n" {1..10} >> tmp2
+
+history -c
+HISTFILE=tmp1 history -r
+HISTFILE=tmp2 history -n
+
+history | grep orig | wc -l
+history | grep new | wc -l
+
+## STDOUT:
+10
+10
+## END
+
+
 
 #### HISTFILE is defined initially
 echo '
@@ -195,4 +233,131 @@ status=1
 ## END
 
 
+#### HISTSIZE shrinks the history when changed
+
+cd $TMP
+printf "cmd %s\n" {1..10} > tmp
+HISTFILE=tmp
+history -c
+history -r
+history | wc -l
+HISTSIZE=5
+history | wc -l
+
+## STDOUT:
+10
+5
+## END
+
+
+#### HISTFILESIZE shrinks the history file when changed
+
+cd $TMP
+printf "cmd %s\n" {1..10} > tmp
+HISTFILE=tmp
+HISTFILESIZE=5
+cat tmp | wc -l
+
+## STDOUT:
+5
+## END
+
+
+#### set -o history / set +o history
+
+cd $TMP
+printf "echo %s\n" {1..3} > tmp
+HISTFILE=tmp $SH -i <<'EOF'
+set +o history
+echo "not recorded" >> /dev/null
+set -o history
+echo "recorded" >> /dev/null
+EOF
+
+case $SH in bash) echo '^D' ;; esac
+
+grep "not recorded" tmp >> /dev/null
+echo status=$?
+grep "recorded" tmp >> /dev/null
+echo status=$?
+
+## STDOUT:
+^D
+status=1
+status=0
+## END
+
+
+#### shopt histappend toggle check
+
+shopt -s histappend
+echo status=$?
+shopt -p histappend
+shopt -u histappend
+echo status=$?
+shopt -p histappend
+
+# match osh's behaviour of echoing ^D for EOF
+case $SH in bash) echo '^D' ;; esac
+
+## STDOUT:
+status=0
+shopt -s histappend
+status=0
+shopt -u histappend
+^D
+## END
+
+
+#### shopt histappend 
+# When set, bash always appends when exiting, no matter what. 
+# When unset, bash will append anyway as long the # of new commands < the hist length
+# Either way, the file is truncated to HISTFILESIZE afterwards.
+
+cd $TMP 
+
+export HISTSIZE=10
+export HISTFILESIZE=1000
+export HISTFILE=tmp
+
+histappend_test() {
+  local histopt
+  if [[ "$1" == true ]]; then
+    histopt='shopt -s histappend'
+  else
+    histopt='shopt -u histappend'
+  fi
+
+  printf "cmd orig%s\n" {1..10} > tmp
+
+  $SH --norc -i <<EOF
+  HISTSIZE=2 # Stifle the history down to 2 commands
+  $histopt
+  # Now run >2 commands to trigger bash's overwrite behavior
+  echo cmd new1 > /dev/null
+  echo cmd new2 > /dev/null
+  echo cmd new3 > /dev/null
+EOF
+
+  case $SH in bash) echo '^D' ;; esac
+}
+
+# If we force histappend, bash won't overwrite the history file
+histappend_test true
+grep -q "orig" tmp
+echo status=$?
+
+# If we don't force histappend, bash will overwrite the history file when the number of cmds exceeds HISTSIZE
+histappend_test false
+grep -q "orig" tmp
+echo status=$?
+
+
+
+## STDOUT:
+^D
+status=0
+^D
+status=1
+## END
 


### PR DESCRIPTION
I've been pretty busy with my real job, but I was able to get some time to put together the necessary history tests for my next steps with histappend, and some extras, too.

## Stupid bash behavior

So, shell option `histappend` is tricky to test, because bash usually appends _anyway_. At some point shortly after people had the resources to run multiple shells on the same machine, they realized overwriting the history file on exit was a bad idea.

The actual bash logic when histappend is unset is to compare the number of new commands in the session with the size of the in-mem history. If the new commands # exceeds the history size, it overwrites the history file entirely, otherwise it appends. This is friendlier to multiple bash sessions, since even with file truncation, it'll keep recent entries written by other bash sessions.

The only thing setting `shopt -s histappend` does is force bash to _always_ append... which honestly, should be the default.


## `history -r` bug

I also added tests for other history behaviors. One in particular stood out.

The existing spec test for `history -r` was not quite correct. `history -r` actually _appends_, rather than replaces, the file's contents to the current in-mem history. If run twice, you should expect to see all the new commands doubled up.

The old version only tested running `history -r` once, which can't distinguish between replacing and appending, so I fixed that.

BUT, for whatever reason, it's only failing on the Python side. I'm not sure why, but the test passes on the C++ side. Not sure what that's about yet.


## Spec test list
1. history -w
2. history -n
3. Fix incorrect history -r test
4. HISTSIZE test
5. HISTFILESIZE test
6. set +/-o history
7. shopt histappend