### PR TITLE
add spec test for nested subshell parse error

### DIFF
--- a/spec/divergence.test.sh
+++ b/spec/divergence.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh zsh ash
-## oils_failures_allowed: 2
+## oils_failures_allowed: 3
 
 # This file relates to:
 #
@@ -54,4 +54,12 @@ good
 bad
 
 ## STDOUT:
+## END
+
+#### Nested subshell (#2398)
+
+# found on line 137 of the zdiff util from gzip
+((echo foo) | tr o 0)
+## STDOUT:
+f00
 ## END


### PR DESCRIPTION
gzip has a utility script called zdiff. It gets used at some point in the check step when building gzip from source. It also makes use of nested subshells in a few places. The osh parser is tripping over these. Here's an example from a simple script.

    ((echo foo) | tr o 0)
         ^~~
    _tmp/foo.sh:1: Unexpected token after arithmetic expression (Id.Word_Compound != Id.Arith_RParen)

Other shells seem to handle this case, so in preparation for an inbound fix, this commit adds a new spec test to cover it.

Related to #2398