### PR TITLE
feat: new build option 'build-packages-overlayfs'

### DIFF
--- a/regtest/aports-common.sh
+++ b/regtest/aports-common.sh
@@ -2,6 +2,7 @@
 
 readonly CHROOT_DIR=_chroot/aports-build
 readonly CHROOT_HOME_DIR=$CHROOT_DIR/home/udu
+readonly OVERLAY_BASE_DIR=$(pwd)/_chroot/overlay
 
 # For he.oils.pub
 readonly BASE_DIR=_tmp/aports-build
@@ -21,6 +22,39 @@ enter-rootfs() {
 
 enter-rootfs-user() {
   enter-rootfs -u udu "$@"
+}
+
+enter-rootfs-user-overlayfs() {
+  local artifacts="$1"
+  local name="$2"
+  shift 2
+  if [[ -z "$1" ]]; then
+    echo "need a name for overlayfs"
+    exit 1
+  fi
+  # Where everything lands
+  local upper="$OVERLAY_BASE_DIR/$name"
+  # Just for the temporary representation of everything
+  local merged="$OVERLAY_BASE_DIR/${name}_merged"
+  # Temporary folder for underneath work of overlayfs
+  local work="$OVERLAY_BASE_DIR/${name}_work"
+
+  mkdir -p "$OVERLAY_BASE_DIR"
+  for d in "$upper" "$merged" "$work"; do
+    sudo rm -rf "$d"
+    mkdir -p "$d"
+  done
+  sudo mount -t overlay overlay "-olowerdir=$CHROOT_DIR,upperdir=$upper,workdir=$work" "$merged"
+  $merged/enter-chroot -u udu "$@"
+  sudo umount -l "$merged"
+
+  # TODO: This path is a bit much hardcoded..
+  rsync -avu "$upper/home/udu/oils/_tmp/aports-guest" "$REPORT_DIR/"
+  # Delete, because they require a lot of storage!
+  for d in "$upper" "$merged" "$work"; do
+    sudo rm -rf "$d" || true
+  done
+
 }
 
 # Note: these functions aren't used.  bwrap is problematic when the container

--- a/regtest/aports-common.sh
+++ b/regtest/aports-common.sh
@@ -48,12 +48,14 @@ enter-rootfs-user-overlayfs() {
   $merged/enter-chroot -u udu "$@"
   sudo umount -l "$merged"
 
-  # TODO: This path is a bit much hardcoded..
   rsync -avu "$upper/home/udu/oils/_tmp/aports-guest" "$REPORT_DIR/"
-  # Delete, because they require a lot of storage!
-  for d in "$upper" "$merged" "$work"; do
-    sudo rm -rf "$d" || true
-  done
+  if false; then
+    # TODO: This path is a bit much hardcoded..
+    # Delete, because they require a lot of storage!
+    for d in "$upper" "$merged" "$work"; do
+      sudo rm -rf "$d" || true
+    done
+  fi
 
 }
 

--- a/regtest/aports-run.sh
+++ b/regtest/aports-run.sh
@@ -221,6 +221,26 @@ build-packages() {
   ' dummy0 "$config" "${package_dirs[@]}"
 }
 
+build-packages-overlayfs() {
+  # https://wiki.alpinelinux.org/wiki/Abuild_and_Helpers#Basic_usage
+  local package_filter=${1:-}
+  local config=${2:-baseline}
+
+  local -a package_dirs=( $(package-dirs "$package_filter") )
+
+  banner "Building ${#package_dirs[@]} packages (filter $package_filter)"
+  for package in "${package_dirs[@]}"; do
+    echo "Building $package"
+    enter-rootfs-user-overlayfs "$config" "$package" sh -c '
+    config=$1
+    shift
+
+    cd oils
+    regtest/aports-guest.sh build-package "$config" "$@"
+    ' dummy0 "$config" "$package"
+  done
+}
+
 clean-host-and-guest() {
   # host dir _tmp/aports-build
   rm -r -f -v $BASE_DIR

--- a/regtest/aports-setup.sh
+++ b/regtest/aports-setup.sh
@@ -12,6 +12,8 @@
 #
 # Other commands:
 #   $0 remove-chroot
+#
+set -e
 
 : ${LIB_OSH=stdlib/osh}
 source $LIB_OSH/bash-strict.sh

--- a/regtest/aports-setup.sh
+++ b/regtest/aports-setup.sh
@@ -12,8 +12,6 @@
 #
 # Other commands:
 #   $0 remove-chroot
-#
-set -e
 
 : ${LIB_OSH=stdlib/osh}
 source $LIB_OSH/bash-strict.sh

--- a/regtest/aports.md
+++ b/regtest/aports.md
@@ -17,7 +17,7 @@ This is how I did it manually:
 
     $ sudo visudo -f /etc/sudoers.d/no-timeout
 
-The result shoudl be:
+The result should be:
 
     $ sudo cat /etc/sudoers.d/no-timeout
     Defaults:andy timestamp_timeout=-1


### PR DESCRIPTION
As discussed in Zulip, a way to build all packages completely independently. This doesn't use `xargs ...` yet, so definitely needs more improvements. But my local test with a bunch of packages seemed to work. The only questionable thing: I can't tell how much overhead it creates.

A quick test showed that `aaudit` builds in about 2.5 seconds with `overlayfs` and about 2 seconds without. But that could just be the preparation, in which case it would mean that there is about half a second added per package, which is about 15mins additional time required. If it's overhead at build time, well, then it will probably take longer :)