### PR TITLE
aports: install readline-dev in chroot

### DIFF
--- a/regtest/aports-setup.sh
+++ b/regtest/aports-setup.sh
@@ -143,7 +143,7 @@ add-build-deps() {
   # findutils: for xargs --process-slot-var
   enter-rootfs sh -c '
   apk update
-  apk add alpine-sdk abuild-rootbld pigz doas bash python3 findutils
+  apk add alpine-sdk abuild-rootbld pigz doas bash python3 findutils readline-dev
   '
 
   # enter-rootfs -u udu bash -c 'echo "hi from bash"'


### PR DESCRIPTION
This will make interactively debugging bugs inside the chroot much easier.

The paths all lined up, so our `configure` picks this up without any extra changes.

```
$ enter-overlayfs-user osh-as-sh.overlay
~ $ history
   0 history
   1 ls
   2 history
   3 set -o vi
   4 vim
   5 vi
   6 clear
   7 ls
   8 history
(reverse-i-search)'set': set -o vi
```