### PR TITLE
add spec test for #2411

### DIFF
--- a/spec/temp-binding.test.sh
+++ b/spec/temp-binding.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: dash bash zsh mksh ash yash
-## oils_failures_allowed: 0
+## oils_failures_allowed: 1
 
 # forked from spec/ble-idioms
 # the IFS= eval 'local x' bug
@@ -151,4 +151,11 @@ x=
 ---
 x=
 x=
+## END
+
+#### FOO=bar $unset - temp binding, then empty argv from unquoted unset var (#2411)
+foo=alive! $unset
+echo $foo
+## STDOUT:
+alive!
 ## END


### PR DESCRIPTION
This commit adds a failing spec test to tickle a crash that happens when evaluating a simple command that is prefixed with variable bindings.