### PR TITLE
check argv length before indexing (fixes #2411)

### DIFF
--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -304,6 +304,9 @@ def _PrefixBindingsPersist(cmd_val):
             return True
         elif case(cmd_value_e.Argv):
             cmd_val = cast(cmd_value.Argv, UP_cmd_val)
+            if len(cmd_val.argv) == 0:
+                return True
+
             arg0 = cmd_val.argv[0]
 
             # exec is an EXCEPTION to the SPECIAL builtin rule.

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -305,6 +305,9 @@ def _PrefixBindingsPersist(cmd_val):
         elif case(cmd_value_e.Argv):
             cmd_val = cast(cmd_value.Argv, UP_cmd_val)
             if len(cmd_val.argv) == 0:
+                # This is counter-intuitive, but bash appears to preserve
+                # bindings in this case. Try the following snippet:
+                # bash -c 'A=a $B; echo $A' (prints "a")
                 return True
 
             arg0 = cmd_val.argv[0]

--- a/spec/temp-binding.test.sh
+++ b/spec/temp-binding.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: dash bash zsh mksh ash yash
-## oils_failures_allowed: 1
+## oils_failures_allowed: 0
 
 # forked from spec/ble-idioms
 # the IFS= eval 'local x' bug


### PR DESCRIPTION
We have a helper to check if prefix bindings should pe preserved when running a simple command. This check requires checking the first argument of the command line, but doesn't check the length before indexing. This commit patches the helper to return early if argv is empty. From there, the usual command execution logic will take care of the rest: either a noop, or erroring out if strict_argv is enabled.