### PR TITLE
fix python2 build with newer compilers

### DIFF
--- a/deps/source.medo/bash/WEDGE
+++ b/deps/source.medo/bash/WEDGE
@@ -20,7 +20,7 @@ wedge-make() {
 
   # --without-bash-malloc for Alpine only -- musl libc incompatibility?
   # https://patchwork.ozlabs.org/project/buildroot/patch/20170523171931.18744-1-dsabogalcc@gmail.com/
-  time $src_dir/configure --without-bash-malloc --prefix=$install_dir
+  time $src_dir/configure --without-bash-malloc --prefix=$install_dir CFLAGS="-std=gnu99"
 
   time make
 }

--- a/deps/source.medo/python2/WEDGE
+++ b/deps/source.medo/python2/WEDGE
@@ -24,7 +24,7 @@ wedge-make() {
   # install'
   # And then Dockerfile.* may need the corresponding runtime deps
 
-  time $src_dir/configure --prefix=$install_dir
+  time $src_dir/configure --prefix=$install_dir CFLAGS="-std=gnu99"
 
   time make
 


### PR DESCRIPTION
I also ran into issue #2312 on my arch installation. It seems like newer compilers have a conflict with the source code that is defining its own `true` and `false` (the issue has a more detailed explanation). Forcing an older C standard when building seems to resolve the issue.

The compiler on my system is `gcc (GCC) 15.1.1 20250425` 