### PR TITLE
Deps build errors

### DIFF
--- a/deps/source.medo/bash/WEDGE
+++ b/deps/source.medo/bash/WEDGE
@@ -20,7 +20,7 @@ wedge-make() {
 
   # --without-bash-malloc for Alpine only -- musl libc incompatibility?
   # https://patchwork.ozlabs.org/project/buildroot/patch/20170523171931.18744-1-dsabogalcc@gmail.com/
-  time $src_dir/configure --without-bash-malloc --prefix=$install_dir CFLAGS="-std=gnu99"
+  time $src_dir/configure --without-bash-malloc --prefix=$install_dir CFLAGS="-std=gnu99 -Wno-error=implicit-function-declaration"
 
   time make
 }

--- a/deps/source.medo/busybox/WEDGE
+++ b/deps/source.medo/busybox/WEDGE
@@ -17,7 +17,8 @@ wedge-make() {
 
   # Out of tree instructions from INSTALL
   make KBUILD_SRC=$src_dir -f $src_dir/Makefile defconfig
-
+  # disable the tc module, since thats broken on linux kernels > 6.8
+  sed -i 's/CONFIG_TC=y/CONFIG_TC=n/' .config
   time make
 }
 

--- a/deps/source.medo/zsh/WEDGE
+++ b/deps/source.medo/zsh/WEDGE
@@ -26,7 +26,8 @@ wedge-make() {
   # This creates config.modules
   time $src_dir/configure \
     --disable-dynamic --with-tcsetpgrp \
-    --prefix=$install_dir 
+    --prefix=$install_dir \
+    CFLAGS="-Wno-error=incompatible-pointer-types"
 
   # For some reason the regex module isn't included if we --disable-dynamic?
   # name=zsh/regex modfile=Src/Modules/regex.mdd link=no


### PR DESCRIPTION
Fixed some small issues with building dependencies, which seem to no longer build when using gcc >= 14 (in the case of bash and zsh) or when using linux kernel >= 6.8 (busybox).

For busybox the recommended workaround was just disabling the module.

For bash and zsh the fix was treating certain compile errors as warnings (which was the default behavior for those errors before gcc 14). So I think these changes should also not really have an impact on existing working environments with an older gcc.

For reference here were the compilation issues:

zsh: `termcap.c:45:14: error: conflicting types for ‘boolcodes’; have ‘char *[]’`
busybox: `tc.c:296:24: error: invalid use of undefined type ‘struct tc_cbq_lssopt’`
bash: `parse.y:5741:21: error: implicit declaration of function ‘count_all_jobs’ [-Wimplicit-function-declaration]`