### PR TITLE
Fix ESRCH crash running fast external commands

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -1332,9 +1332,13 @@ class Process(Job):
         """Run this process synchronously."""
         self.StartProcess(why)
         # ShellExecutor might be calling this for the last part of a pipeline.
-        if self.parent_pipeline is None:
-            # QUESTION: Can the PGID of a single process just be the PID?  i.e. avoid
-            # calling getpgid()?
+        #
+        # Only resolve the pgid when job control is on: MaybeGiveTerminal()
+        # no-ops otherwise, and the getpgid() races with the child's exit —
+        # on macOS, getpgid() of a zombie fails with ESRCH, which escaped as
+        # "oils I/O error (main): No such process" / exit 2 when a fast
+        # external command finished before the parent got scheduled.
+        if self.parent_pipeline is None and self.job_control.Enabled():
             self.job_control.MaybeGiveTerminal(posix.getpgid(self.pid))
         return self.Wait(waiter)
 

--- a/core/process.py
+++ b/core/process.py
@@ -1334,7 +1334,7 @@ class Process(Job):
         # ShellExecutor might be calling this for the last part of a pipeline.
         #
         # Only resolve the pgid when job control is on: MaybeGiveTerminal()
-        # no-ops otherwise, and the getpgid() races with the child's exit —
+        # no-ops otherwise, and the getpgid() races with the child's exit --
         # on macOS, getpgid() of a zombie fails with ESRCH, which escaped as
         # "oils I/O error (main): No such process" / exit 2 when a fast
         # external command finished before the parent got scheduled.


### PR DESCRIPTION
## Repro

```
osh -c 'cat file'
```

Run it in a parallel loop on a loaded machine (macOS is easiest), and a few percent of runs die with:

```
oils I/O error (main): No such process
```

exit status 2, empty stdout. (We hit this in the wild via vite-task, which substitutes osh for /bin/sh to run cached task commands; the flake was initially misattributed to its exec interposition.)

## Cause

`Process::RunProcess` resolves the child's pgid with `getpgid()` immediately after `fork()`, before waiting on it:

```python
self.job_control.MaybeGiveTerminal(posix.getpgid(self.pid))
```

On macOS, `getpgid()` of a child that has already exited — a zombie — fails with ESRCH (verified with a standalone C repro). The resulting `OSError` escapes to `main()`, which prints the line above and returns 2. The parent loses the race whenever it is descheduled past the child's exit, which is why it takes CPU contention to reproduce.

## Fix

The pgid is only used to maybe move the child's process group into the terminal foreground, and `MaybeGiveTerminal()` is already a no-op when job control is disabled. Gate the `getpgid()` on `job_control.Enabled()` so batch shells never pay the race. The job-control path is unchanged.

## Testing

I could not run the spec suite (its harness needs Python 2), so I verified against the 0.37.0 tarball build with the same change applied to the generated C++:

- The failing shapes (`cat f`, `echo x; cat f`, `echo x > f; cat f`, `sh -c '...'` nesting, pipelines) in 8-way parallel loops, 2000 runs: 0 failures, versus ~5% before.
- A smoke script covering external commands, pipelines, redirects, command substitution, background + `wait`, loops, and non-zero exit: byte-identical stdout/stderr and exit code against the unpatched binary.